### PR TITLE
plumbing commands: locate-project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "cargo-test-support",
  "clap",
  "clap-cargo",
+ "serde_json",
  "snapbox",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ default = []
 anyhow = "1.0.96"
 clap = { version = "4.5.31", features = ["derive"] }
 clap-cargo = "0.15.2"
+serde_json = "1.0.139"
 
 [dev-dependencies]
 automod = "1.0.14"

--- a/src/bin/cargo-plumbing/cli.rs
+++ b/src/bin/cargo-plumbing/cli.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 #[command(bin_name = "cargo")]
 #[command(styles = clap_cargo::style::CLAP_STYLING)]
 pub(crate) enum Command {
-    #[command(subcommand)]
+    #[command(subcommand, about = "Execute low-level plumbing commands for Cargo")]
     Plumbing(crate::plumbing::Plumbing),
 }
 

--- a/src/bin/cargo-plumbing/plumbing.rs
+++ b/src/bin/cargo-plumbing/plumbing.rs
@@ -22,7 +22,7 @@ pub(crate) struct LocateProjectArgs {
 
     /// The representation in which to print the project location
     #[arg(long = "message-format", value_enum, default_value_t = MessageFormat::Json)]
-    pub message_format: MessageFormat,
+    message_format: MessageFormat,
 
     /// Path to the `Cargo.toml` file to start searching from
     #[arg(long = "manifest-path", value_name = "path")]

--- a/src/bin/cargo-plumbing/plumbing.rs
+++ b/src/bin/cargo-plumbing/plumbing.rs
@@ -1,11 +1,120 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::{Subcommand, Args, ValueEnum};
 use cargo_plumbing::CargoResult;
 
-#[derive(Debug, clap::Subcommand)]
+#[derive(Debug, Subcommand)]
 #[command(styles = clap_cargo::style::CLAP_STYLING)]
-pub(crate) enum Plumbing {}
+pub(crate) enum Plumbing {
+    /// Locate the project manifest file (`Cargo.toml`)
+    #[command(name = "locate-project")]
+    LocateProject(LocateProjectArgs),
+    // ... other plumbing commands
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct LocateProjectArgs {
+    /// Locate the workspace root `Cargo.toml` instead of the current package
+    #[arg(long)]
+    pub workspace: bool,
+
+    /// The representation in which to print the project location
+    #[arg(long = "message-format", value_enum, default_value_t = MessageFormat::Json)]
+    pub message_format: MessageFormat,
+
+    /// Path to the `Cargo.toml` file to start searching from
+    #[arg(long = "manifest-path", value_name = "path")]
+    pub manifest_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum MessageFormat {
+    Json,
+    Plain,
+}
 
 impl Plumbing {
     pub(crate) fn exec(self) -> CargoResult<()> {
-        anyhow::bail!("not implemented");
+        match self {
+            Plumbing::LocateProject(args) => exec_locate_project(args),
+        }
+    }
+}
+
+fn exec_locate_project(
+    args: LocateProjectArgs
+) -> CargoResult<()> {
+    // Determine starting directory
+    let start_dir = match args.manifest_path.clone() {
+        Some(path) if path.is_file() && path.file_name() == Some("Cargo.toml".as_ref()) => {
+            path.parent().unwrap().to_path_buf()
+        }
+        Some(path) => path,
+        None => env::current_dir()?,
+    };
+
+    // Find the project manifest
+    let manifest = find_manifest(&start_dir)?;
+
+    // If workspace root requested, find workspace root
+    let project_manifest = if args.workspace {
+        let ws_dir = find_workspace_root(&manifest.parent().unwrap())?;
+        ws_dir.join("Cargo.toml")
+    } else {
+        manifest
+    };
+
+    // Output
+    match args.message_format {
+        MessageFormat::Json => {
+            let root_str = project_manifest.to_string_lossy();
+            let obj = serde_json::json!({ "root": root_str });
+            println!("{}", serde_json::to_string(&obj)?);
+        }
+        MessageFormat::Plain => {
+            println!("{}", project_manifest.display());
+        }
+    }
+
+    Ok(())
+}
+
+/// Search upward from `start` for a `Cargo.toml` file
+fn find_manifest(start: &Path) -> CargoResult<PathBuf> {
+    let mut dir = start.to_path_buf();
+    loop {
+        let candidate = dir.join("Cargo.toml");
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+        if let Some(parent) = dir.parent() {
+            dir = parent.to_path_buf();
+        } else {
+            anyhow::bail!("failed to find Cargo.toml starting from {}", start.display());
+        }
+    }
+}
+
+/// Search upward from `start` for a `Cargo.toml` containing a `[workspace]` table
+fn find_workspace_root(start: &Path) -> CargoResult<PathBuf> {
+    let mut dir = start.to_path_buf();
+    loop {
+        let candidate = dir.join("Cargo.toml");
+        if candidate.is_file() {
+            let content = fs::read_to_string(&candidate)?;
+            if content.lines().any(|l| l.trim().starts_with("[workspace]")) {
+                return Ok(dir);
+            }
+        }
+        if let Some(parent) = dir.parent() {
+            dir = parent.to_path_buf();
+        } else {
+            anyhow::bail!(
+                "failed to find workspace root Cargo.toml from {}",
+                start.display()
+            );
+        }
     }
 }


### PR DESCRIPTION
Implemeted a plumbing command "cargo plumbing locate-project"

"cargo run -- -h"
<img width="1667" alt="Screenshot 2025-04-23 at 1 22 24 AM" src="https://github.com/user-attachments/assets/ab3b253e-a7a0-42b7-91d7-ecf637bae2a1" />

"cargo run -- plumbing -h"
<img width="906" alt="Screenshot 2025-04-23 at 1 24 30 AM" src="https://github.com/user-attachments/assets/5ee35a40-5ff3-4041-89c5-b2ce8793fdb2" />

"cargo run -- plumbing locate-project -h"
<img width="1108" alt="Screenshot 2025-04-23 at 1 27 48 AM" src="https://github.com/user-attachments/assets/613f57cd-eab3-4bec-bd0c-d8ee51a2677f" />

"cargo run -- plumbing locate-project" or "cargo run -- plumbing locate-project --message-format json"
<img width="709" alt="Screenshot 2025-04-23 at 1 25 52 AM" src="https://github.com/user-attachments/assets/1d7f417b-f92d-4c1c-814f-89e5ca73b155" />
