### PR TITLE
chore(examples): Add skeleton example for check

### DIFF
--- a/examples/check.rs
+++ b/examples/check.rs
@@ -1,0 +1,17 @@
+use cargo_plumbing::CargoResult;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+struct Args {}
+
+fn run(_args: &Args) -> CargoResult<()> {
+    anyhow::bail!("not implemented!");
+}
+
+fn main() {
+    let args = Args::parse();
+    match run(&args) {
+        Ok(()) => {}
+        Err(e) => println!("error: {e}"),
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/crate-ci/cargo-plumbing/pull/11#discussion_r2155466096. This PR adds a skeleton example for `cargo-check`. The example is still empty as the plumbing commands hasn't been implemented yet.