### PR TITLE
chore: Downgrade schemars for cargo-util-schemas compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,9 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.9.0"
+version = "1.0.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+checksum = "88ef2a6523400a2228db974a8ddc9e1d3deaa04f51bddd7832ef8d7e531bafcc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3064,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.9.0"
+version = "1.0.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+checksum = "c6d4e1945a3c9e58edaa708449b026519f7f4197185e1b5dbc689615c1ad724d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cargo-test-support = "0.7.4"
 cargo-plumbing-schemas = { version = "0.0.1", path = "crates/cargo-plumbing-schemas" }
 clap = "4.5.31"
 clap-cargo = "0.15.2"
-schemars = "0.9.0"
+schemars = "1.0.0-alpha.17"
 serde = "1.0.217"
 serde_json = "1.0.138"
 serde-untagged = "0.1.6"


### PR DESCRIPTION
How is this a downgrade?  0.9.0 was released to replace the 1.0.0 pre-releases