### PR TITLE
test: Improve test names for clarity

### DIFF
--- a/tests/testsuite/locate_manifest.rs
+++ b/tests/testsuite/locate_manifest.rs
@@ -5,7 +5,7 @@ use cargo_test_support::str;
 use crate::ProjectExt;
 
 #[cargo_test]
-fn simple() {
+fn finds_package_manifest() {
     let p = project().build();
 
     p.cargo_plumbing("plumbing locate-manifest")
@@ -27,7 +27,7 @@ fn simple() {
 }
 
 #[cargo_test]
-fn manifest_path_arg() {
+fn finds_package_manifest_via_manifest_path_flag() {
     let p = project().file("src/lib.rs", "").build();
 
     let wd = p.root().join("src");
@@ -53,7 +53,7 @@ fn manifest_path_arg() {
 }
 
 #[cargo_test]
-fn found_virtual_manifest() {
+fn finds_virtual_manifest() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -104,7 +104,7 @@ fn found_virtual_manifest() {
 }
 
 #[cargo_test]
-fn no_manifest_found() {
+fn errors_when_no_manifest() {
     let p = project().no_manifest().build();
 
     p.cargo_plumbing("plumbing locate-manifest")

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -6,7 +6,7 @@ use snapbox::IntoData;
 use crate::ProjectExt;
 
 #[cargo_test]
-fn simple_with_deps() {
+fn package_with_deps() {
     Package::new("a", "1.0.0")
         .file("src/lib.rs", r#"pub fn f() -> i32 { 12 }"#)
         .publish();
@@ -221,7 +221,7 @@ fn simple_with_deps() {
 }
 
 #[cargo_test]
-fn workspace_real_manifest_with_deps() {
+fn workspace_package_with_inherited_deps() {
     Package::new("a", "1.0.0")
         .file("src/lib.rs", r#"pub fn f() -> i32 { 12 }"#)
         .publish();
@@ -502,7 +502,7 @@ fn workspace_real_manifest_with_deps() {
 }
 
 #[cargo_test]
-fn workspace_real_manifest_with_multiple_members() {
+fn workspace_package_with_members() {
     let p = project()
         .file("crate2/src/lib.rs", "")
         .file(
@@ -910,7 +910,7 @@ fn workspace_real_manifest_with_multiple_members() {
 }
 
 #[cargo_test]
-fn workspace_virtual_manifest_with_multiple_members() {
+fn virtual_workspace_with_members() {
     let p = project()
         .file("crate2/src/lib.rs", "")
         .file(
@@ -1756,7 +1756,7 @@ fn workspace_member_with_inherited_deps() {
 }
 
 #[cargo_test]
-fn workspace_member_via_workspace_field() {
+fn workspace_member_via_package_workspace_key() {
     Package::new("a", "1.0.0")
         .file("src/lib.rs", r#"pub fn f() -> i32 { 12 }"#)
         .publish();


### PR DESCRIPTION
Some existing test names did not clearly indicate what they test. This PR renames those tests for better clarity.

I decided to remove words like "simple" as I think "simple" can be subjective and does not clearly describe the tests.