### PR TITLE
feat(lock): Allow the caller to specify the contents a `Cargo.lock`

### DIFF
--- a/crates/cargo-plumbing-schemas/lock-dependencies.in.schema.json
+++ b/crates/cargo-plumbing-schemas/lock-dependencies.in.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LockDependenciesIn",
+  "description": "Input messages for `cargo-plumbing lock-dependencies`.",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "reason": {
+          "type": "string",
+          "const": "lockfile"
+        }
+      },
+      "required": [
+        "reason"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "rev": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dependencies": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "const": "locked-package"
+        }
+      },
+      "required": [
+        "reason",
+        "id"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "unused": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NormalizedDependency"
+          }
+        },
+        "reason": {
+          "type": "string",
+          "const": "unused-patches"
+        }
+      },
+      "required": [
+        "reason",
+        "unused"
+      ]
+    }
+  ],
+  "$defs": {
+    "NormalizedDependency": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "rev": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "checksum": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dependencies": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ]
+    }
+  }
+}

--- a/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
+++ b/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
@@ -7,6 +7,34 @@ use serde::{Deserialize, Serialize};
 use crate::lockfile::{NormalizedDependency, NormalizedPatch};
 use crate::MessageIter;
 
+/// Input messages for `cargo-plumbing lock-dependencies`.
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "kebab-case")]
+#[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
+#[allow(clippy::large_enum_variant)]
+pub enum LockDependenciesIn {
+    Lockfile {
+        version: Option<u32>,
+    },
+    LockedPackage {
+        #[serde(flatten)]
+        package: NormalizedDependency,
+    },
+    UnusedPatches {
+        unused: NormalizedPatch,
+    },
+}
+
+impl LockDependenciesIn {
+    /// Creates an iterator to parse a stream of [`LockDependenciesIn`]s.
+    pub fn parse_stream<R: Read>(input: R) -> MessageIter<R, Self> {
+        MessageIter {
+            input,
+            _m: PhantomData::<Self>,
+        }
+    }
+}
+
 /// Output messages for `cargo-plumbing lock-dependencies`.
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "reason", rename_all = "kebab-case")]
@@ -43,5 +71,12 @@ fn dump_lock_dependencies_schema() {
     snapbox::assert_data_eq!(
         dump,
         snapbox::file!("../lock-dependencies.out.schema.json").raw()
+    );
+
+    let schema = schemars::schema_for!(LockDependenciesIn);
+    let dump = serde_json::to_string_pretty(&schema).unwrap();
+    snapbox::assert_data_eq!(
+        dump,
+        snapbox::file!("../lock-dependencies.in.schema.json").raw()
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod cargo;
+pub mod ops;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,0 +1,1 @@
+pub mod resolve;

--- a/src/ops/resolve.rs
+++ b/src/ops/resolve.rs
@@ -1,0 +1,221 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use cargo::core::{
+    PackageId, PackageIdSpec, Resolve, ResolveVersion, SourceId, SourceKind, Workspace,
+};
+use cargo::util::Graph;
+use cargo::CargoResult;
+use cargo_plumbing_schemas::lockfile::{NormalizedDependency, NormalizedPatch};
+
+use crate::cargo::core::resolver::encode::build_path_deps;
+
+/// Converts plumbing messages into an incomplete [`Resolve`]
+///
+/// The `features` and `summaries` fields of the returned struct is empty.
+pub fn into_resolve(
+    ws: &Workspace<'_>,
+    version: Option<u32>,
+    packages: Vec<NormalizedDependency>,
+    patch: NormalizedPatch,
+) -> CargoResult<Resolve> {
+    let path_deps = build_path_deps(ws)?;
+
+    let mut checksums = HashMap::new();
+
+    let live_pkgs = {
+        let mut all_pkgs = HashSet::new();
+        let mut live_pkgs = HashMap::new();
+        for pkg in packages.iter() {
+            if !all_pkgs.insert(pkg.id.clone()) {
+                anyhow::bail!("package `{}` is specified twice", pkg.id.name());
+            }
+
+            let source_id = get_path_deps_source_id(&path_deps, pkg.id.name(), pkg.id.version());
+            let Ok(Some(id)) = spec_to_id(pkg.id.clone(), source_id) else {
+                continue;
+            };
+
+            if let Some(cksum) = &pkg.checksum {
+                checksums.insert(id, Some(cksum.clone()));
+            }
+
+            live_pkgs.insert(pkg.id.clone(), (id, pkg));
+        }
+        live_pkgs
+    };
+
+    // When decoding a V2 version the edges in `dependencies` aren't
+    // guaranteed to have either version or source information. This `map`
+    // is used to find package ids even if dependencies have missing
+    // information. This map is from name to version to source to actual
+    // package ID. (various levels to drill down step by step)
+    let mut map = HashMap::new();
+    for (id, _) in live_pkgs.values() {
+        map.entry(id.name().as_str())
+            .or_insert_with(HashMap::new)
+            .entry(id.version())
+            .or_insert_with(HashMap::new)
+            .insert(id.source_id(), *id);
+    }
+
+    let lookup_id = |pkg_id: &PackageIdSpec, source_id: Option<&SourceId>| -> Option<PackageId> {
+        let by_version = map.get(pkg_id.name())?;
+
+        let by_source = match &pkg_id.version() {
+            Some(version) => by_version.get(version)?,
+            None => {
+                if by_version.len() == 1 {
+                    by_version.values().next().unwrap()
+                } else {
+                    return None;
+                }
+            }
+        };
+
+        match &source_id {
+            Some(source) => by_source.get(source).cloned(),
+            None => {
+                let mut path_packages = by_source.values().filter(|p| p.source_id().is_path());
+                if let Some(path) = path_packages.next() {
+                    if path_packages.next().is_some() {
+                        None
+                    } else {
+                        Some(*path)
+                    }
+                } else if by_source.len() == 1 {
+                    Some(*by_source.values().next().unwrap())
+                } else {
+                    None
+                }
+            }
+        }
+    };
+
+    let graph = {
+        let mut g = Graph::new();
+
+        for (id, _) in live_pkgs.values() {
+            g.add(*id);
+        }
+
+        for &(ref id, pkg) in live_pkgs.values() {
+            let Some(ref deps) = pkg.dependencies else {
+                continue;
+            };
+
+            for edge in deps.iter() {
+                let package_id = spec_to_id(edge.clone(), None)?;
+                let source_id = package_id.map(|p| p.source_id());
+                if let Some(to_depend_on) = lookup_id(edge, source_id.as_ref()) {
+                    g.link(*id, to_depend_on);
+                }
+            }
+        }
+        g
+    };
+
+    let replacements = {
+        let mut replacements = HashMap::new();
+        for &(ref id, pkg) in live_pkgs.values() {
+            if let Some(ref replace) = pkg.replace {
+                assert!(pkg.dependencies.is_none());
+                let source_id = id.source_id();
+                if let Some(replace_id) = lookup_id(replace, Some(&source_id)) {
+                    replacements.insert(*id, replace_id);
+                }
+            }
+        }
+        replacements
+    };
+
+    let unused_patches = {
+        let mut unused_patches = Vec::new();
+        for pkg in patch.unused {
+            let source_id = get_path_deps_source_id(&path_deps, pkg.id.name(), pkg.id.version());
+            let Ok(Some(id)) = spec_to_id(pkg.id.clone(), source_id) else {
+                continue;
+            };
+            unused_patches.push(id);
+        }
+        unused_patches
+    };
+
+    let metadata = BTreeMap::new();
+    let features = HashMap::new();
+    let summaries = HashMap::new();
+
+    let version = match version {
+        Some(4) => ResolveVersion::V4,
+        Some(3) => ResolveVersion::V3,
+        Some(2) => ResolveVersion::V2,
+        Some(1) => ResolveVersion::V1,
+        None => ResolveVersion::V2,
+        Some(_) => anyhow::bail!("invalid lockfile version"),
+    };
+
+    Ok(Resolve::new(
+        graph,
+        replacements,
+        features,
+        checksums,
+        metadata,
+        unused_patches,
+        version,
+        summaries,
+    ))
+}
+
+pub fn get_path_deps_source_id<'a>(
+    path_deps: &'a HashMap<String, HashMap<semver::Version, SourceId>>,
+    package_name: &str,
+    package_version: Option<semver::Version>,
+) -> Option<&'a SourceId> {
+    path_deps.iter().find_map(|(name, version_source)| {
+        if name != package_name || version_source.is_empty() {
+            return None;
+        }
+
+        if version_source.len() == 1 {
+            return Some(version_source.values().next().unwrap());
+        }
+
+        if let Some(pkg_version) = &package_version {
+            if let Some(source_id) = version_source.get(pkg_version) {
+                return Some(source_id);
+            }
+        }
+
+        None
+    })
+}
+
+pub fn spec_to_id(
+    spec: PackageIdSpec,
+    source_id: Option<&SourceId>,
+) -> CargoResult<Option<PackageId>> {
+    if let Some(kind) = spec.kind() {
+        if let Some(url) = spec.url() {
+            if let Some(version) = spec.version() {
+                let name = spec.name();
+                let source_id = match kind {
+                    SourceKind::Git(git_ref) => SourceId::for_git(url, git_ref.clone()),
+                    SourceKind::Registry | SourceKind::SparseRegistry => {
+                        SourceId::for_registry(url)
+                    }
+                    _ => anyhow::bail!("unsupported source"),
+                }?;
+
+                return Ok(Some(PackageId::new(name.into(), version, source_id)));
+            }
+        }
+    }
+
+    if let Some(source_id) = source_id {
+        if let Some(version) = spec.version() {
+            let name = spec.name();
+            return Ok(Some(PackageId::new(name.into(), version, *source_id)));
+        }
+    }
+
+    Ok(None)
+}

--- a/tests/testsuite/lock_dependencies.rs
+++ b/tests/testsuite/lock_dependencies.rs
@@ -654,8 +654,8 @@ fn lock_dependencies_conservatively_using_previous_lock() {
     "version": 4
   },
   {
-    "checksum": "b4e7ca49a1828dc529a7857517b75c0f2db074db0b546d8626043db8618c097b",
-    "id": "registry+https://github.com/rust-lang/crates.io-index#a@1.0.1",
+    "checksum": "3a351dafbc8a3a9cba7c06dfe8caa11a3a45f800a336bb5b913a8f1e2652d454",
+    "id": "registry+https://github.com/rust-lang/crates.io-index#a@1.0.0",
     "reason": "locked-package"
   },
   {
@@ -765,19 +765,19 @@ fn lock_dependencies_conservatively_using_previous_lock_with_old_lockfile_versio
 [
   {
     "reason": "lockfile",
-    "version": 4
+    "version": null
   },
   {
-    "checksum": "b4e7ca49a1828dc529a7857517b75c0f2db074db0b546d8626043db8618c097b",
-    "id": "registry+https://github.com/rust-lang/crates.io-index#a@1.0.1",
-    "reason": "locked-package"
+    "reason": "locked-package",
+    "id": "registry+https://github.com/rust-lang/crates.io-index#a@1.0.0",
+    "checksum": "3a351dafbc8a3a9cba7c06dfe8caa11a3a45f800a336bb5b913a8f1e2652d454"
   },
   {
+    "reason": "locked-package",
+    "id": "lock-dependencies-test@0.1.0",
     "dependencies": [
       "a"
-    ],
-    "id": "lock-dependencies-test@0.1.0",
-    "reason": "locked-package"
+    ]
   }
 ]
 "#]]


### PR DESCRIPTION
`lock-dependencies` can't read the `Cargo.lock` file on disk yet. The main blocker is the inability to convert messages from `read-lockfile` into a `Resolve`. This PR aims to solve that issue by providing the necessary conversion functionality. This is also needed for `resolve-features`, which directly operates on a `Resolve`.

Part of #36 