### PR TITLE
feat(lockfile): Parse `Metadata` to `NormalizedMetadata`

### DIFF
--- a/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
+++ b/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
@@ -4,7 +4,7 @@ use std::{io::Read, marker::PhantomData};
 
 use serde::{Deserialize, Serialize};
 
-use crate::lockfile::{Metadata, NormalizedDependency, NormalizedPatch};
+use crate::lockfile::{NormalizedDependency, NormalizedMetadata, NormalizedPatch};
 use crate::MessageIter;
 
 /// Output messages for `cargo-plumbing lock-dependencies`.
@@ -22,7 +22,7 @@ pub enum LockDependenciesOut {
     },
     Metadata {
         #[serde(flatten)]
-        metadata: Metadata,
+        metadata: NormalizedMetadata,
     },
     UnusedPatches {
         unused: NormalizedPatch,

--- a/crates/cargo-plumbing-schemas/src/lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/lockfile.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, fmt};
 use cargo_util_schemas::core::PackageIdSpec;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-pub type Metadata = BTreeMap<String, String>;
+pub type NormalizedMetadata = BTreeMap<PackageIdSpec, String>;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -21,7 +21,7 @@ pub struct NormalizedResolve {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub package: Vec<NormalizedDependency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<Metadata>,
+    pub metadata: Option<NormalizedMetadata>,
     #[serde(default, skip_serializing_if = "NormalizedPatch::is_empty")]
     pub patch: NormalizedPatch,
 }

--- a/crates/cargo-plumbing-schemas/src/read_lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/read_lockfile.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
 
-use crate::lockfile::{Metadata, NormalizedDependency, NormalizedPatch};
+use crate::lockfile::{NormalizedDependency, NormalizedMetadata, NormalizedPatch};
 use crate::MessageIter;
 
 /// Output messages for `cargo-plumbing read-lockfile`.
@@ -23,7 +23,7 @@ pub enum ReadLockfileOut {
     },
     Metadata {
         #[serde(flatten)]
-        metadata: Metadata,
+        metadata: NormalizedMetadata,
     },
     UnusedPatches {
         unused: NormalizedPatch,

--- a/crates/cargo-plumbing-schemas/src/write_lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/write_lockfile.rs
@@ -4,7 +4,7 @@ use std::{io::Read, marker::PhantomData};
 
 use serde::{Deserialize, Serialize};
 
-use crate::lockfile::{Metadata, NormalizedDependency, NormalizedPatch};
+use crate::lockfile::{NormalizedDependency, NormalizedMetadata, NormalizedPatch};
 use crate::MessageIter;
 
 /// Input messages for `cargo-plumbing write-lockfile`.
@@ -22,7 +22,7 @@ pub enum WriteLockfileIn {
     },
     Metadata {
         #[serde(flatten)]
-        metadata: Metadata,
+        metadata: NormalizedMetadata,
     },
     UnusedPatches {
         unused: NormalizedPatch,

--- a/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
+++ b/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
@@ -9,8 +9,8 @@ use cargo::ops::resolve_with_previous;
 use cargo::sources::SourceConfigMap;
 use cargo::{CargoResult, GlobalContext};
 use cargo_plumbing::cargo::core::resolver::encode::{
-    encodable_package_id, encodable_resolve_node, encodable_source_id, EncodableDependency,
-    EncodeState,
+    encodable_package_id, encodable_resolve_node, encodable_source_id, normalize_metadata,
+    EncodableDependency, EncodeState,
 };
 use cargo_plumbing_schemas::lock_dependencies::LockDependenciesOut;
 use cargo_plumbing_schemas::lockfile::NormalizedPatch;
@@ -83,6 +83,7 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
     }
 
     if !metadata.is_empty() {
+        let metadata = normalize_metadata(metadata)?;
         let msg = LockDependenciesOut::Metadata { metadata };
         gctx.shell().print_json(&msg)?;
     }

--- a/tests/testsuite/read_lockfile.rs
+++ b/tests/testsuite/read_lockfile.rs
@@ -617,7 +617,7 @@ fn old_lockfile() {
   },
   {
     "reason": "metadata",
-    "checksum a 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)": "3436ae58a84bb2033accec0cb50c6611f312249899579714793e0d0509470cd9"
+    "registry+https://github.com/rust-lang/crates.io-index#a@0.1.0": "3436ae58a84bb2033accec0cb50c6611f312249899579714793e0d0509470cd9"
   }
 ]
 "#]]


### PR DESCRIPTION
The key part of `Metadata` is actually `checksum {EncodablePackageId}`. We can normalize this `EncodablePackageId` into a `PackageIdSpec` and use it in a normalized metadata format.

Noticed this while working on #69 where parsing the metadata table requires parsing an `EncodablePackageId`.