### PR TITLE
feat(lock): Normalize checksums to be with packages

### DIFF
--- a/crates/cargo-plumbing-schemas/lock-dependencies.out.schema.json
+++ b/crates/cargo-plumbing-schemas/lock-dependencies.out.schema.json
@@ -66,21 +66,6 @@
     {
       "type": "object",
       "properties": {
-        "reason": {
-          "type": "string",
-          "const": "metadata"
-        }
-      },
-      "additionalProperties": {
-        "type": "string"
-      },
-      "required": [
-        "reason"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
         "unused": {
           "type": "array",
           "items": {

--- a/crates/cargo-plumbing-schemas/read-lockfile.out.schema.json
+++ b/crates/cargo-plumbing-schemas/read-lockfile.out.schema.json
@@ -66,21 +66,6 @@
     {
       "type": "object",
       "properties": {
-        "reason": {
-          "type": "string",
-          "const": "metadata"
-        }
-      },
-      "additionalProperties": {
-        "type": "string"
-      },
-      "required": [
-        "reason"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
         "unused": {
           "type": "array",
           "items": {

--- a/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
+++ b/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
@@ -4,7 +4,7 @@ use std::{io::Read, marker::PhantomData};
 
 use serde::{Deserialize, Serialize};
 
-use crate::lockfile::{NormalizedDependency, NormalizedMetadata, NormalizedPatch};
+use crate::lockfile::{NormalizedDependency, NormalizedPatch};
 use crate::MessageIter;
 
 /// Output messages for `cargo-plumbing lock-dependencies`.
@@ -19,10 +19,6 @@ pub enum LockDependenciesOut {
     LockedPackage {
         #[serde(flatten)]
         package: NormalizedDependency,
-    },
-    Metadata {
-        #[serde(flatten)]
-        metadata: NormalizedMetadata,
     },
     UnusedPatches {
         unused: NormalizedPatch,

--- a/crates/cargo-plumbing-schemas/src/lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/lockfile.rs
@@ -7,12 +7,10 @@
 //! future, they will be used for other lockfile-related commands, such as `lock-dependencies`
 //! and `write-lockfile`.
 
-use std::{collections::BTreeMap, fmt};
+use std::fmt;
 
 use cargo_util_schemas::core::PackageIdSpec;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-pub type NormalizedMetadata = BTreeMap<PackageIdSpec, String>;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -20,8 +18,6 @@ pub type NormalizedMetadata = BTreeMap<PackageIdSpec, String>;
 pub struct NormalizedResolve {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub package: Vec<NormalizedDependency>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<NormalizedMetadata>,
     #[serde(default, skip_serializing_if = "NormalizedPatch::is_empty")]
     pub patch: NormalizedPatch,
 }

--- a/crates/cargo-plumbing-schemas/src/read_lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/read_lockfile.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
 
-use crate::lockfile::{NormalizedDependency, NormalizedMetadata, NormalizedPatch};
+use crate::lockfile::{NormalizedDependency, NormalizedPatch};
 use crate::MessageIter;
 
 /// Output messages for `cargo-plumbing read-lockfile`.
@@ -20,10 +20,6 @@ pub enum ReadLockfileOut {
     LockedPackage {
         #[serde(flatten)]
         package: NormalizedDependency,
-    },
-    Metadata {
-        #[serde(flatten)]
-        metadata: NormalizedMetadata,
     },
     UnusedPatches {
         unused: NormalizedPatch,

--- a/crates/cargo-plumbing-schemas/src/write_lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/write_lockfile.rs
@@ -4,7 +4,7 @@ use std::{io::Read, marker::PhantomData};
 
 use serde::{Deserialize, Serialize};
 
-use crate::lockfile::{NormalizedDependency, NormalizedMetadata, NormalizedPatch};
+use crate::lockfile::{NormalizedDependency, NormalizedPatch};
 use crate::MessageIter;
 
 /// Input messages for `cargo-plumbing write-lockfile`.
@@ -19,10 +19,6 @@ pub enum WriteLockfileIn {
     LockedPackage {
         #[serde(flatten)]
         package: NormalizedDependency,
-    },
-    Metadata {
-        #[serde(flatten)]
-        metadata: NormalizedMetadata,
     },
     UnusedPatches {
         unused: NormalizedPatch,

--- a/crates/cargo-plumbing-schemas/write-lockfile.in.schema.json
+++ b/crates/cargo-plumbing-schemas/write-lockfile.in.schema.json
@@ -66,21 +66,6 @@
     {
       "type": "object",
       "properties": {
-        "reason": {
-          "type": "string",
-          "const": "metadata"
-        }
-      },
-      "additionalProperties": {
-        "type": "string"
-      },
-      "required": [
-        "reason"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
         "unused": {
           "type": "array",
           "items": {

--- a/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
+++ b/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
@@ -9,8 +9,8 @@ use cargo::ops::resolve_with_previous;
 use cargo::sources::SourceConfigMap;
 use cargo::{CargoResult, GlobalContext};
 use cargo_plumbing::cargo::core::resolver::encode::{
-    encodable_package_id, encodable_resolve_node, encodable_source_id, normalize_metadata,
-    EncodableDependency, EncodeState,
+    encodable_resolve_node, encodable_source_id, normalize_packages, EncodableDependency,
+    EncodeState,
 };
 use cargo_plumbing_schemas::lock_dependencies::LockDependenciesOut;
 use cargo_plumbing_schemas::lockfile::NormalizedPatch;
@@ -44,6 +44,15 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
         true,
     )?;
 
+    let mut ids: Vec<_> = resolve.iter().collect();
+    ids.sort();
+    let state = EncodeState::new(&resolve);
+    let packages = ids
+        .iter()
+        .map(|&id| encodable_resolve_node(id, &resolve, &state))
+        .collect::<Vec<_>>();
+    let metadata = resolve.metadata().clone();
+
     let version = match resolve.version() {
         ResolveVersion::V5 => Some(5),
         ResolveVersion::V4 => Some(4),
@@ -53,39 +62,9 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
     gctx.shell()
         .print_json(&LockDependenciesOut::Lockfile { version })?;
 
-    let mut ids: Vec<_> = resolve.iter().collect();
-    ids.sort();
-
-    let state = EncodeState::new(&resolve);
-
-    let packages = ids
-        .iter()
-        .map(|&id| encodable_resolve_node(id, &resolve, &state))
-        .collect::<Vec<_>>();
-
-    let mut metadata = resolve.metadata().clone();
-
-    if resolve.version() == ResolveVersion::V1 {
-        for &id in ids.iter().filter(|id| !id.source_id().is_path()) {
-            let checksum = match resolve.checksums()[&id] {
-                Some(ref s) => &s[..],
-                None => "<none>",
-            };
-            let id = encodable_package_id(id, &state, resolve.version());
-            metadata.insert(format!("checksum {id}"), checksum.to_owned());
-        }
-    }
-
-    for package in packages {
-        let package = package.normalize()?;
-        let msg = LockDependenciesOut::LockedPackage { package };
-        gctx.shell().print_json(&msg)?;
-    }
-
-    if !metadata.is_empty() {
-        let metadata = normalize_metadata(metadata)?;
-        let msg = LockDependenciesOut::Metadata { metadata };
-        gctx.shell().print_json(&msg)?;
+    for package in normalize_packages(None, Some(packages), Some(metadata))? {
+        gctx.shell()
+            .print_json(&LockDependenciesOut::LockedPackage { package })?;
     }
 
     let unused: Vec<_> = resolve

--- a/src/bin/cargo-plumbing/plumbing/read_lockfile.rs
+++ b/src/bin/cargo-plumbing/plumbing/read_lockfile.rs
@@ -45,10 +45,6 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
         gctx.shell()
             .print_json(&ReadLockfileOut::UnusedPatches { unused: n.patch })?;
     }
-    if let Some(metadata) = n.metadata {
-        gctx.shell()
-            .print_json(&ReadLockfileOut::Metadata { metadata })?;
-    }
 
     Ok(())
 }

--- a/src/bin/cargo-plumbing/plumbing/write_lockfile.rs
+++ b/src/bin/cargo-plumbing/plumbing/write_lockfile.rs
@@ -40,7 +40,6 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
             WriteLockfileIn::Lockfile { version } => lock_version = version,
             WriteLockfileIn::LockedPackage { package } => locked_packages.push(package),
             WriteLockfileIn::UnusedPatches { unused } => unused_patches = Some(unused),
-            _ => {}
         }
     }
 

--- a/tests/testsuite/read_lockfile.rs
+++ b/tests/testsuite/read_lockfile.rs
@@ -606,7 +606,8 @@ fn old_lockfile() {
   },
   {
     "reason": "locked-package",
-    "id": "registry+https://github.com/rust-lang/crates.io-index#a@0.1.0"
+    "id": "registry+https://github.com/rust-lang/crates.io-index#a@0.1.0",
+    "checksum": "3436ae58a84bb2033accec0cb50c6611f312249899579714793e0d0509470cd9"
   },
   {
     "reason": "locked-package",
@@ -614,10 +615,6 @@ fn old_lockfile() {
     "dependencies": [
       "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
     ]
-  },
-  {
-    "reason": "metadata",
-    "registry+https://github.com/rust-lang/crates.io-index#a@0.1.0": "3436ae58a84bb2033accec0cb50c6611f312249899579714793e0d0509470cd9"
   }
 ]
 "#]]


### PR DESCRIPTION
This PR normalizes checksums even further so that they are with packages instead of a separate `metadata` message.

See https://github.com/crate-ci/cargo-plumbing/pull/69#discussion_r2263928923