### PR TITLE
chore: Pull out normalize logic from cargo copy

### DIFF
--- a/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
+++ b/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
@@ -10,10 +10,9 @@ use cargo::ops::resolve_with_previous;
 use cargo::sources::SourceConfigMap;
 use cargo::{CargoResult, GlobalContext};
 use cargo_plumbing::cargo::core::resolver::encode::{
-    encodable_resolve_node, encodable_source_id, normalize_packages, EncodableDependency,
-    EncodeState,
+    encodable_resolve_node, encodable_source_id, EncodableDependency, EncodeState,
 };
-use cargo_plumbing::ops::resolve::into_resolve;
+use cargo_plumbing::ops::resolve::{into_resolve, normalize_dependency, normalize_packages};
 use cargo_plumbing_schemas::lock_dependencies::{LockDependenciesIn, LockDependenciesOut};
 use cargo_plumbing_schemas::lockfile::NormalizedPatch;
 
@@ -101,7 +100,7 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
         .unused_patches()
         .iter()
         .map(|id| {
-            EncodableDependency {
+            normalize_dependency(EncodableDependency {
                 name: id.name().to_string(),
                 version: id.version().to_string(),
                 source: encodable_source_id(id.source_id(), resolve.version()),
@@ -112,8 +111,7 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
                 } else {
                     None
                 },
-            }
-            .normalize()
+            })
         })
         .collect::<Result<Vec<_>, _>>()?;
     if !unused.is_empty() {

--- a/src/bin/cargo-plumbing/plumbing/read_lockfile.rs
+++ b/src/bin/cargo-plumbing/plumbing/read_lockfile.rs
@@ -6,6 +6,7 @@ use anyhow::Context as _;
 use cargo::util::Filesystem;
 use cargo::{CargoResult, GlobalContext};
 use cargo_plumbing::cargo::core::resolver::encode::EncodableResolve;
+use cargo_plumbing::ops::resolve::normalize_resolve;
 use cargo_plumbing_schemas::read_lockfile::ReadLockfileOut;
 
 #[derive(Debug, clap::Args)]
@@ -36,7 +37,7 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
     gctx.shell()
         .print_json(&ReadLockfileOut::Lockfile { version: v.version })?;
 
-    let n = v.normalize()?;
+    let n = normalize_resolve(v)?;
     for package in n.package {
         gctx.shell()
             .print_json(&ReadLockfileOut::LockedPackage { package })?;


### PR DESCRIPTION
Moves normalize logic out of the cargo copy. Provides a clearer distinction on what's cargo and what's cargo-plumbing. Helps with #82 