### PR TITLE
refactor(read-manifest): Use `Utf8PathBuf`

### DIFF
--- a/crates/cargo-plumbing-schemas/src/read_manifest.rs
+++ b/crates/cargo-plumbing-schemas/src/read_manifest.rs
@@ -1,7 +1,8 @@
 //! Messages used by `cargo plumbing read-manifest` command
 
-use std::{io::Read, marker::PhantomData, path::PathBuf};
+use std::{io::Read, marker::PhantomData};
 
+use camino::Utf8PathBuf;
 use cargo_util_schemas::core::PackageIdSpec;
 pub use cargo_util_schemas::manifest::TomlManifest;
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,8 @@ pub enum ReadManifestOut {
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         workspace: bool,
         /// The path to the manifest file that was read.
-        path: PathBuf,
+        #[cfg_attr(feature = "unstable-schema", schemars(with = "String"))]
+        path: Utf8PathBuf,
         /// The package ID specification.
         ///
         /// This command also outputs virtual manifests and virtual manifests don't have

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -106,7 +106,7 @@ fn run(args: &Args) -> CargoResult<()> {
         });
 
         let ReadManifestOut::Manifest { path, .. } = ws_manifest.unwrap();
-        path.join("Cargo.lock")
+        path.join("Cargo.lock").into()
     });
 
     let lockfile = {

--- a/src/bin/cargo-plumbing/plumbing/read_manifest.rs
+++ b/src/bin/cargo-plumbing/plumbing/read_manifest.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Context as _;
+use camino::Utf8PathBuf;
 use cargo::core::{
     find_workspace_root, EitherManifest, MaybePackage, SourceId, Workspace, WorkspaceConfig,
 };
@@ -29,13 +30,13 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
         let msg = match workspace.root_maybe() {
             MaybePackage::Package(pkg) => ReadManifestOut::Manifest {
                 workspace: true,
-                path: gctx.cwd().join(pkg.manifest_path()),
+                path: Utf8PathBuf::try_from(gctx.cwd().join(pkg.manifest_path()))?,
                 pkg_id: Some(pkg.package_id().to_spec()),
                 manifest: pkg.manifest().normalized_toml().clone(),
             },
             MaybePackage::Virtual(v) => ReadManifestOut::Manifest {
                 workspace: true,
-                path: gctx.cwd().join(workspace.root_manifest()),
+                path: Utf8PathBuf::try_from(gctx.cwd().join(workspace.root_manifest()))?,
                 pkg_id: None,
                 manifest: v.normalized_toml().clone(),
             },
@@ -51,7 +52,7 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
         {
             let msg = ReadManifestOut::Manifest {
                 workspace: false,
-                path: gctx.cwd().join(member.manifest_path()),
+                path: Utf8PathBuf::try_from(gctx.cwd().join(member.manifest_path()))?,
                 pkg_id: Some(member.package_id().to_spec()),
                 manifest: member.manifest().normalized_toml().clone(),
             };
@@ -101,7 +102,7 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
 
         let msg = ReadManifestOut::Manifest {
             workspace: ws_manifest_path.is_none(),
-            path: requested_manifest_path.clone(),
+            path: Utf8PathBuf::try_from(requested_manifest_path.clone())?,
             pkg_id,
             manifest,
         };
@@ -120,7 +121,7 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
 
             let msg = ReadManifestOut::Manifest {
                 workspace: true,
-                path: ws_manifest_path.clone(),
+                path: Utf8PathBuf::try_from(ws_manifest_path.clone())?,
                 pkg_id,
                 manifest,
             };


### PR DESCRIPTION
Back in #49, we used `Utf8PathBuf` for `locate-manifest`. This PR changes `read-manifest` output to also use `Utf8PathBuf`.