### PR TITLE
fix: Remove `Option` from lockfile `version` out messages

### DIFF
--- a/crates/cargo-plumbing-schemas/lock-dependencies.out.schema.json
+++ b/crates/cargo-plumbing-schemas/lock-dependencies.out.schema.json
@@ -7,10 +7,7 @@
       "type": "object",
       "properties": {
         "version": {
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": "integer",
           "format": "uint32",
           "minimum": 0
         },
@@ -20,7 +17,8 @@
         }
       },
       "required": [
-        "reason"
+        "reason",
+        "version"
       ]
     },
     {

--- a/crates/cargo-plumbing-schemas/read-lockfile.out.schema.json
+++ b/crates/cargo-plumbing-schemas/read-lockfile.out.schema.json
@@ -7,10 +7,7 @@
       "type": "object",
       "properties": {
         "version": {
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": "integer",
           "format": "uint32",
           "minimum": 0
         },
@@ -20,7 +17,8 @@
         }
       },
       "required": [
-        "reason"
+        "reason",
+        "version"
       ]
     },
     {

--- a/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
+++ b/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
@@ -47,7 +47,7 @@ impl LockDependenciesIn {
 #[allow(clippy::large_enum_variant)]
 pub enum LockDependenciesOut {
     Lockfile {
-        version: Option<u32>,
+        version: u32,
     },
     /// The locked package from the lockfile
     ///

--- a/crates/cargo-plumbing-schemas/src/lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/lockfile.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
 pub struct NormalizedResolve {
+    pub version: u32,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub package: Vec<NormalizedDependency>,
     #[serde(default, skip_serializing_if = "NormalizedPatch::is_empty")]

--- a/crates/cargo-plumbing-schemas/src/read_lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/read_lockfile.rs
@@ -15,7 +15,7 @@ use crate::MessageIter;
 #[allow(clippy::large_enum_variant)]
 pub enum ReadLockfileOut {
     Lockfile {
-        version: Option<u32>,
+        version: u32,
     },
     /// The locked package from the lockfile
     ///

--- a/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
+++ b/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
@@ -99,7 +99,7 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
     gctx.shell()
         .print_json(&LockDependenciesOut::Lockfile { version })?;
 
-    for package in normalize_packages(None, Some(packages), Some(metadata))? {
+    for package in normalize_packages(None, Some(packages), Some(metadata), None)? {
         gctx.shell()
             .print_json(&LockDependenciesOut::LockedPackage { package })?;
     }

--- a/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
+++ b/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
@@ -91,10 +91,11 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
     let metadata = resolve.metadata().clone();
 
     let version = match resolve.version() {
-        ResolveVersion::V5 => Some(5),
-        ResolveVersion::V4 => Some(4),
-        ResolveVersion::V3 => Some(3),
-        ResolveVersion::V2 | ResolveVersion::V1 => None,
+        ResolveVersion::V5 => 5,
+        ResolveVersion::V4 => 4,
+        ResolveVersion::V3 => 3,
+        ResolveVersion::V2 => 2,
+        ResolveVersion::V1 => 1,
     };
     gctx.shell()
         .print_json(&LockDependenciesOut::Lockfile { version })?;

--- a/src/bin/cargo-plumbing/plumbing/read_lockfile.rs
+++ b/src/bin/cargo-plumbing/plumbing/read_lockfile.rs
@@ -34,10 +34,10 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
         .with_context(|| format!("failed to read file: {}", lock_f.path().display()))?;
 
     let v: EncodableResolve = toml::from_str(&lock_s)?;
-    gctx.shell()
-        .print_json(&ReadLockfileOut::Lockfile { version: v.version })?;
-
     let n = normalize_resolve(v)?;
+
+    gctx.shell()
+        .print_json(&ReadLockfileOut::Lockfile { version: n.version })?;
     for package in n.package {
         gctx.shell()
             .print_json(&ReadLockfileOut::LockedPackage { package })?;

--- a/tests/testsuite/lock_dependencies.rs
+++ b/tests/testsuite/lock_dependencies.rs
@@ -877,7 +877,7 @@ fn lock_dependencies_conservatively_using_previous_lock_with_old_lockfile_versio
 [
   {
     "reason": "lockfile",
-    "version": null
+    "version": 1
   },
   {
     "reason": "locked-package",
@@ -916,16 +916,15 @@ fn lock_dependencies_conservatively_using_previous_lock_with_old_lockfile_versio
     "version": null
   },
   {
-    "reason": "locked-package",
     "id": "registry+https://github.com/rust-lang/crates.io-index#a@1.0.0",
-    "checksum": "3a351dafbc8a3a9cba7c06dfe8caa11a3a45f800a336bb5b913a8f1e2652d454"
+    "reason": "locked-package"
   },
   {
-    "reason": "locked-package",
-    "id": "lock-dependencies-test@0.1.0",
     "dependencies": [
-      "a"
-    ]
+      "registry+https://github.com/rust-lang/crates.io-index#a@1.0.0"
+    ],
+    "id": "lock-dependencies-test@0.1.0",
+    "reason": "locked-package"
   }
 ]
 "#]]

--- a/tests/testsuite/lock_dependencies.rs
+++ b/tests/testsuite/lock_dependencies.rs
@@ -913,7 +913,7 @@ fn lock_dependencies_conservatively_using_previous_lock_with_old_lockfile_versio
 [
   {
     "reason": "lockfile",
-    "version": null
+    "version": 1
   },
   {
     "id": "registry+https://github.com/rust-lang/crates.io-index#a@1.0.0",

--- a/tests/testsuite/read_lockfile.rs
+++ b/tests/testsuite/read_lockfile.rs
@@ -602,19 +602,19 @@ fn old_lockfile() {
 [
   {
     "reason": "lockfile",
-    "version": null
+    "version": 1
   },
   {
-    "reason": "locked-package",
+    "checksum": "3436ae58a84bb2033accec0cb50c6611f312249899579714793e0d0509470cd9",
     "id": "registry+https://github.com/rust-lang/crates.io-index#a@0.1.0",
-    "checksum": "3436ae58a84bb2033accec0cb50c6611f312249899579714793e0d0509470cd9"
+    "reason": "locked-package"
   },
   {
-    "reason": "locked-package",
-    "id": "foo@0.0.1",
     "dependencies": [
       "registry+https://github.com/rust-lang/crates.io-index#a@0.1.0"
-    ]
+    ],
+    "id": "foo@0.0.1",
+    "reason": "locked-package"
   }
 ]
 "#]]


### PR DESCRIPTION
Part of #75 

In this PR, the `Lockfile` messages have their version type changed from `Option<u32>` to `u32`. I decided to split having an enum for the lockfile version, because I feel that having an enum is not as important as changing the field to remove the `Option`.

In the issue, I talked about having an enumerated `ResolveVersion`. However, making a new `ResolveVersion` under `cargo-plumbing-schemas` can be confusing as the same enum name is used in `cargo`.

Future work may include moving `ResolveVersion` from `cargo` to `cargo-util-schemas` so that it can be used for the messages. I'm open to any other suggestions.