### PR TITLE
fix: Remove `Lockfile` input messages from `resolve-features` and `lock-dependencies`

### DIFF
--- a/crates/cargo-plumbing-schemas/lock-dependencies.in.schema.json
+++ b/crates/cargo-plumbing-schemas/lock-dependencies.in.schema.json
@@ -4,26 +4,6 @@
   "description": "Input messages for `cargo-plumbing lock-dependencies`.",
   "oneOf": [
     {
-      "type": "object",
-      "properties": {
-        "version": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint32",
-          "minimum": 0
-        },
-        "reason": {
-          "type": "string",
-          "const": "lockfile"
-        }
-      },
-      "required": [
-        "reason"
-      ]
-    },
-    {
       "description": "The locked package from the lockfile\n\nExpected to be inputted in a lexicographical order based on the package\nname, matching the order of the `[[package]]` entries in a `Cargo.lock`\nfile.",
       "type": "object",
       "properties": {

--- a/crates/cargo-plumbing-schemas/resolve-features.in.schema.json
+++ b/crates/cargo-plumbing-schemas/resolve-features.in.schema.json
@@ -24,26 +24,6 @@
     {
       "type": "object",
       "properties": {
-        "version": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint32",
-          "minimum": 0
-        },
-        "reason": {
-          "type": "string",
-          "const": "lockfile"
-        }
-      },
-      "required": [
-        "reason"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
         "id": {
           "type": "string"
         },

--- a/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
+++ b/crates/cargo-plumbing-schemas/src/lock_dependencies.rs
@@ -13,9 +13,6 @@ use crate::MessageIter;
 #[cfg_attr(feature = "unstable-schema", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum LockDependenciesIn {
-    Lockfile {
-        version: Option<u32>,
-    },
     /// The locked package from the lockfile
     ///
     /// Expected to be inputted in a lexicographical order based on the package

--- a/crates/cargo-plumbing-schemas/src/resolve_features.rs
+++ b/crates/cargo-plumbing-schemas/src/resolve_features.rs
@@ -17,9 +17,6 @@ pub enum ResolveFeaturesIn {
         #[cfg_attr(feature = "unstable-schema", schemars(with = "Option<String>"))]
         id: PackageIdSpec,
     },
-    Lockfile {
-        version: Option<u32>,
-    },
     LockedPackage {
         #[serde(flatten)]
         package: NormalizedDependency,

--- a/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
+++ b/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
@@ -45,13 +45,11 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
 
     let messages = LockDependenciesIn::parse_stream(BufReader::new(stdin));
 
-    let mut lockfile_version: Option<u32> = None;
     let mut locked_packages = Vec::new();
     let mut unused_patches = None;
 
     for message in messages {
         match message? {
-            LockDependenciesIn::Lockfile { version } => lockfile_version = version,
             LockDependenciesIn::LockedPackage { package } => locked_packages.push(package),
             LockDependenciesIn::UnusedPatches { unused } => unused_patches = Some(unused),
         }
@@ -60,7 +58,6 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
     let previous_resolve = if !locked_packages.is_empty() {
         Some(into_resolve(
             &ws,
-            lockfile_version,
             locked_packages,
             unused_patches.unwrap_or_default(),
         )?)

--- a/src/bin/cargo-plumbing/plumbing/resolve_features.rs
+++ b/src/bin/cargo-plumbing/plumbing/resolve_features.rs
@@ -60,14 +60,12 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
 
     let messages = ResolveFeaturesIn::parse_stream(BufReader::new(stdin));
 
-    let mut lock_version = None;
     let mut locked_packages = Vec::new();
     let mut unused_patches = None;
     let mut specs = Vec::new();
 
     for message in messages {
         match message? {
-            ResolveFeaturesIn::Lockfile { version } => lock_version = version,
             ResolveFeaturesIn::LockedPackage { package } => locked_packages.push(package),
             ResolveFeaturesIn::UnusedPatches { unused } => unused_patches = Some(unused),
             ResolveFeaturesIn::Manifest { id } => specs.push(id),
@@ -78,12 +76,7 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
         anyhow::bail!("incomplete input. no packages found.");
     }
 
-    let resolve = into_resolve(
-        &ws,
-        lock_version,
-        locked_packages,
-        unused_patches.unwrap_or_default(),
-    )?;
+    let resolve = into_resolve(&ws, locked_packages, unused_patches.unwrap_or_default())?;
     let cli_features = CliFeatures::from_command_line(
         &args.features,
         args.all_features,

--- a/src/ops/resolve.rs
+++ b/src/ops/resolve.rs
@@ -19,7 +19,6 @@ use crate::cargo::core::resolver::encode::{
 /// The `features` and `summaries` fields of the returned struct is empty.
 pub fn into_resolve(
     ws: &Workspace<'_>,
-    version: Option<u32>,
     packages: Vec<NormalizedDependency>,
     patch: NormalizedPatch,
 ) -> CargoResult<Resolve> {
@@ -149,14 +148,9 @@ pub fn into_resolve(
     let features = HashMap::new();
     let summaries = HashMap::new();
 
-    let version = match version {
-        Some(4) => ResolveVersion::V4,
-        Some(3) => ResolveVersion::V3,
-        Some(2) => ResolveVersion::V2,
-        Some(1) => ResolveVersion::V1,
-        None => ResolveVersion::V2,
-        Some(_) => anyhow::bail!("invalid lockfile version"),
-    };
+    // We use a separate schema from cargo's lockfile versions, where it is comparable to the V4
+    // lockfile version.
+    let version = ResolveVersion::V4;
 
     Ok(Resolve::new(
         graph,

--- a/tests/testsuite/resolve_features.rs
+++ b/tests/testsuite/resolve_features.rs
@@ -1,3 +1,4 @@
+use cargo_plumbing_schemas::read_lockfile::ReadLockfileOut;
 use cargo_plumbing_schemas::read_manifest::ReadManifestOut;
 use cargo_plumbing_schemas::resolve_features::ResolveFeaturesIn;
 use cargo_test_macro::cargo_test;
@@ -65,7 +66,19 @@ fn package_with_path_deps() {
         .arg(p.root().join("Cargo.lock"))
         .with_status(0)
         .run();
-    stdin.push_str(&String::from_utf8(out.stdout).unwrap());
+    let out: String = ReadLockfileOut::parse_stream(&*out.stdout)
+        .filter_map(Result::ok)
+        .filter(|msg| {
+            matches!(
+                msg,
+                ReadLockfileOut::LockedPackage { .. } | ReadLockfileOut::UnusedPatches { .. }
+            )
+        })
+        .map(|msg| serde_json::to_string(&msg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    stdin.push_str(&out);
 
     p.cargo_plumbing("plumbing resolve-features")
         .with_stdin(stdin)
@@ -180,7 +193,19 @@ fn package_with_varying_deps_sources() {
         .arg(p.root().join("Cargo.lock"))
         .with_status(0)
         .run();
-    stdin.push_str(&String::from_utf8(out.stdout).unwrap());
+    let out: String = ReadLockfileOut::parse_stream(&*out.stdout)
+        .filter_map(Result::ok)
+        .filter(|msg| {
+            matches!(
+                msg,
+                ReadLockfileOut::LockedPackage { .. } | ReadLockfileOut::UnusedPatches { .. }
+            )
+        })
+        .map(|msg| serde_json::to_string(&msg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    stdin.push_str(&out);
 
     p.cargo_plumbing("plumbing resolve-features")
         .with_stdin(stdin)
@@ -284,7 +309,19 @@ fn package_with_features() {
         .arg(p.root().join("Cargo.lock"))
         .with_status(0)
         .run();
-    stdin.push_str(&String::from_utf8(out.stdout).unwrap());
+    let out: String = ReadLockfileOut::parse_stream(&*out.stdout)
+        .filter_map(Result::ok)
+        .filter(|msg| {
+            matches!(
+                msg,
+                ReadLockfileOut::LockedPackage { .. } | ReadLockfileOut::UnusedPatches { .. }
+            )
+        })
+        .map(|msg| serde_json::to_string(&msg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    stdin.push_str(&out);
 
     p.cargo_plumbing("plumbing resolve-features")
         .with_stdin(&stdin)
@@ -467,7 +504,19 @@ fn package_with_optional_dep_without_features() {
         .arg(p.root().join("Cargo.lock"))
         .with_status(0)
         .run();
-    stdin.push_str(&String::from_utf8(out.stdout).unwrap());
+    let out: String = ReadLockfileOut::parse_stream(&*out.stdout)
+        .filter_map(Result::ok)
+        .filter(|msg| {
+            matches!(
+                msg,
+                ReadLockfileOut::LockedPackage { .. } | ReadLockfileOut::UnusedPatches { .. }
+            )
+        })
+        .map(|msg| serde_json::to_string(&msg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    stdin.push_str(&out);
 
     p.cargo_plumbing("plumbing resolve-features")
         .with_stdin(&stdin)
@@ -607,7 +656,19 @@ fn package_with_proc_macro_deps_features() {
         .arg(p.root().join("Cargo.lock"))
         .with_status(0)
         .run();
-    stdin.push_str(&String::from_utf8(out.stdout).unwrap());
+    let out: String = ReadLockfileOut::parse_stream(&*out.stdout)
+        .filter_map(Result::ok)
+        .filter(|msg| {
+            matches!(
+                msg,
+                ReadLockfileOut::LockedPackage { .. } | ReadLockfileOut::UnusedPatches { .. }
+            )
+        })
+        .map(|msg| serde_json::to_string(&msg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    stdin.push_str(&out);
 
     p.cargo_plumbing("plumbing resolve-features")
         .with_stdin(&stdin)
@@ -697,7 +758,19 @@ fn package_with_target_specific_dep() {
         .arg(p.root().join("Cargo.lock"))
         .with_status(0)
         .run();
-    stdin.push_str(&String::from_utf8(out.stdout).unwrap());
+    let out: String = ReadLockfileOut::parse_stream(&*out.stdout)
+        .filter_map(Result::ok)
+        .filter(|msg| {
+            matches!(
+                msg,
+                ReadLockfileOut::LockedPackage { .. } | ReadLockfileOut::UnusedPatches { .. }
+            )
+        })
+        .map(|msg| serde_json::to_string(&msg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    stdin.push_str(&out);
 
     p.cargo_plumbing("plumbing resolve-features")
         .with_stdin(&stdin)
@@ -817,7 +890,19 @@ fn workspace_package_with_members_with_features() {
         .arg(p.root().join("Cargo.lock"))
         .with_status(0)
         .run();
-    stdin.push_str(&String::from_utf8(out.stdout).unwrap());
+    let out: String = ReadLockfileOut::parse_stream(&*out.stdout)
+        .filter_map(Result::ok)
+        .filter(|msg| {
+            matches!(
+                msg,
+                ReadLockfileOut::LockedPackage { .. } | ReadLockfileOut::UnusedPatches { .. }
+            )
+        })
+        .map(|msg| serde_json::to_string(&msg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    stdin.push_str(&out);
 
     p.cargo_plumbing("plumbing resolve-features")
         .with_stdin(&stdin)
@@ -1025,7 +1110,19 @@ fn package_with_dev_deps() {
         .arg(p.root().join("Cargo.lock"))
         .with_status(0)
         .run();
-    stdin.push_str(&String::from_utf8(out.stdout).unwrap());
+    let out: String = ReadLockfileOut::parse_stream(&*out.stdout)
+        .filter_map(Result::ok)
+        .filter(|msg| {
+            matches!(
+                msg,
+                ReadLockfileOut::LockedPackage { .. } | ReadLockfileOut::UnusedPatches { .. }
+            )
+        })
+        .map(|msg| serde_json::to_string(&msg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    stdin.push_str(&out);
 
     p.cargo_plumbing("plumbing resolve-features")
         .with_stdin(&stdin)


### PR DESCRIPTION
Closes #99 

The problem turns out to not be the plumbing commands, but instead badly formatted `stdin` inputs causing some messages to not be read. Also in https://github.com/crate-ci/cargo-plumbing/pull/98#discussion_r2308203405, I forgot to filter out the `Lockfile` message from the `read-lockfile` output which also caused some messages to not be read.