### PR TITLE
refactor: Remove unnecessary if on checksum

### DIFF
--- a/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
+++ b/src/bin/cargo-plumbing/plumbing/lock_dependencies.rs
@@ -112,11 +112,7 @@ pub(crate) fn exec(gctx: &GlobalContext, args: Args) -> CargoResult<()> {
                 source: encodable_source_id(id.source_id(), resolve.version()),
                 dependencies: None,
                 replace: None,
-                checksum: if resolve.version() >= ResolveVersion::V2 {
-                    resolve.checksums().get(id).and_then(|x| x.clone())
-                } else {
-                    None
-                },
+                checksum: resolve.checksums().get(id).and_then(|x| x.clone()),
             })
         })
         .collect::<Result<Vec<_>, _>>()?;


### PR DESCRIPTION
Currently, in `lock-dependencies`, the `checksum` field is supplied an if expression based on the resolve version. This is unnecessary since the resulting resolve version from `resolve_with_previous` outputs the latest version. The implementation always results in the `if` branch execution and never the `else` branch. We also want plumbing messages to be separate from cargo's lockfile versioning, so having the if expression doesn't make much sense.

This PR removes said unnecessary if expression in place of the `if` branch.