### PR TITLE
feat(resolve-features): Resolve features target selection

### DIFF
--- a/crates/cargo-plumbing-schemas/resolve-features.in.schema.json
+++ b/crates/cargo-plumbing-schemas/resolve-features.in.schema.json
@@ -6,8 +6,23 @@
     {
       "type": "object",
       "properties": {
-        "id": {
+        "workspace": {
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the manifest file that was read.",
           "type": "string"
+        },
+        "pkg_id": {
+          "description": "The package ID specification",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "manifest": {
+          "description": "The fully parsed and deserialized manifest content.",
+          "$ref": "#/$defs/TomlManifest"
         },
         "reason": {
           "type": "string",
@@ -16,7 +31,8 @@
       },
       "required": [
         "reason",
-        "id"
+        "path",
+        "manifest"
       ]
     },
     {
@@ -83,6 +99,1483 @@
     }
   ],
   "$defs": {
+    "TomlManifest": {
+      "description": "This type is used to deserialize `Cargo.toml` files.",
+      "type": "object",
+      "properties": {
+        "cargo-features": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "package": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlPackage"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "project": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlPackage"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "badges": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "features": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "lib": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlTarget"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "bin": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/TomlTarget"
+          }
+        },
+        "example": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/TomlTarget"
+          }
+        },
+        "test": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/TomlTarget"
+          }
+        },
+        "bench": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/TomlTarget"
+          }
+        },
+        "dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "dev-dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "dev_dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "build-dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "build_dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "target": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/TomlPlatform"
+          }
+        },
+        "lints": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableLints"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hints": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hints"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "workspace": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlWorkspace"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlProfiles"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "patch": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/$defs/TomlDependency"
+            }
+          }
+        },
+        "replace": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/TomlDependency"
+          }
+        }
+      }
+    },
+    "TomlPackage": {
+      "description": "Represents the `package`/`project` sections of a `Cargo.toml`.\n\nNote that the order of the fields matters, since this is the order they\nare serialized to a TOML file. For example, you cannot have values after\nthe field `metadata`, since it is a table and values cannot appear after\ntables.",
+      "type": "object",
+      "properties": {
+        "edition": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rust-version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField3"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "build": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlPackageBuild"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "metabuild": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "default-target": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "forced-target": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField3"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField3"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "publish": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField4"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "workspace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "im-a-teapot": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autolib": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autobins": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autoexamples": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autotests": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "autobenches": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default-run": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "homepage": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "documentation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readme": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField5"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "keywords": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField3"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "categories": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField3"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "license": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "license-file": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "repository": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritableField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resolver": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "InheritableField": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "type": "string"
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "$ref": "#/$defs/TomlInheritedField"
+        }
+      ]
+    },
+    "TomlInheritedField": {
+      "type": "object",
+      "properties": {
+        "workspace": {
+          "$ref": "#/$defs/WorkspaceValue"
+        }
+      },
+      "required": [
+        "workspace"
+      ]
+    },
+    "WorkspaceValue": {
+      "type": "boolean"
+    },
+    "InheritableField2": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "$ref": "#/$defs/SemVer"
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "$ref": "#/$defs/TomlInheritedField"
+        }
+      ]
+    },
+    "SemVer": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "InheritableField3": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "$ref": "#/$defs/TomlInheritedField"
+        }
+      ]
+    },
+    "TomlPackageBuild": {
+      "anyOf": [
+        {
+          "description": "If build scripts are disabled or enabled.\nIf true, `build.rs` in the root folder will be the build script.",
+          "type": "boolean"
+        },
+        {
+          "description": "Path of Build Script if there's just one script.",
+          "type": "string"
+        },
+        {
+          "description": "Vector of paths if multiple build script are to be used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "StringOrVec": {
+      "description": "This can be parsed from either a TOML string or array,\nbut is always stored as a vector.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "InheritableField4": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "$ref": "#/$defs/VecStringOrBool"
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "$ref": "#/$defs/TomlInheritedField"
+        }
+      ]
+    },
+    "VecStringOrBool": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "InheritableField5": {
+      "description": "An enum that allows for inheriting keys from a workspace in a Cargo.toml.",
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "$ref": "#/$defs/StringOrBool"
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "$ref": "#/$defs/TomlInheritedField"
+        }
+      ]
+    },
+    "StringOrBool": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "TomlValue": true,
+    "TomlTarget": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "crate-type": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "crate_type": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filename": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "test": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "doctest": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "bench": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "doc": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "doc-scrape-examples": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "proc-macro": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "proc_macro": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "harness": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "required-features": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "edition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "InheritableDependency": {
+      "anyOf": [
+        {
+          "description": "The type that is used when not inheriting from a workspace.",
+          "$ref": "#/$defs/TomlDependency"
+        },
+        {
+          "description": "The type when inheriting from a workspace.",
+          "$ref": "#/$defs/TomlInheritedDependency"
+        }
+      ]
+    },
+    "TomlDependency": {
+      "anyOf": [
+        {
+          "description": "In the simple format, only a version is specified, eg.\n`package = \"<version>\"`",
+          "type": "string"
+        },
+        {
+          "description": "The simple format is equivalent to a detailed dependency\nspecifying only a version, eg.\n`package = { version = \"<version>\" }`",
+          "$ref": "#/$defs/TomlDetailedDependency"
+        }
+      ]
+    },
+    "TomlDetailedDependency": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "registry": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "registry-index": {
+          "description": "The URL of the `registry` field.\nThis is an internal implementation detail. When Cargo creates a\npackage, it replaces `registry` with `registry-index` so that the\nmanifest contains the correct URL. All users won't have the same\nregistry names configured, so Cargo can't rely on just the name for\ncrates published by other users.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "git": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rev": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "features": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "optional": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default-features": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default_features": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "package": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "public": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "artifact": {
+          "description": "One or more of `bin`, `cdylib`, `staticlib`, `bin:<name>`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lib": {
+          "description": "If set, the artifact should also be a dependency",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "target": {
+          "description": "A platform name, like `x86_64-apple-darwin`",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TomlInheritedDependency": {
+      "type": "object",
+      "properties": {
+        "workspace": {
+          "type": "boolean"
+        },
+        "features": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "default-features": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default_features": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "optional": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "public": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "workspace"
+      ]
+    },
+    "TomlPlatform": {
+      "description": "Corresponds to a `target` entry, but `TomlTarget` is already used.",
+      "type": "object",
+      "properties": {
+        "dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "build-dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "build_dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "dev-dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        },
+        "dev_dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/InheritableDependency"
+          }
+        }
+      }
+    },
+    "InheritableLints": {
+      "type": "object",
+      "properties": {
+        "workspace": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/$defs/TomlLint"
+        }
+      }
+    },
+    "TomlLint": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TomlLintLevel"
+        },
+        {
+          "$ref": "#/$defs/TomlLintConfig"
+        }
+      ]
+    },
+    "TomlLintLevel": {
+      "type": "string",
+      "enum": [
+        "forbid",
+        "deny",
+        "warn",
+        "allow"
+      ]
+    },
+    "TomlLintConfig": {
+      "type": "object",
+      "properties": {
+        "level": {
+          "$ref": "#/$defs/TomlLintLevel"
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int8",
+          "minimum": -128,
+          "maximum": 127,
+          "default": 0
+        }
+      },
+      "required": [
+        "level"
+      ],
+      "additionalProperties": {
+        "$ref": "#/$defs/TomlValue"
+      }
+    },
+    "Hints": {
+      "type": "object",
+      "properties": {
+        "mostly-unused": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "TomlWorkspace": {
+      "type": "object",
+      "properties": {
+        "members": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "exclude": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "default-members": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "resolver": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "package": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InheritablePackage"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependencies": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/TomlDependency"
+          }
+        },
+        "lints": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/$defs/TomlLint"
+            }
+          }
+        }
+      }
+    },
+    "InheritablePackage": {
+      "description": "A group of fields that are inheritable by members of the workspace",
+      "type": "object",
+      "properties": {
+        "version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SemVer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "authors": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "homepage": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "documentation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readme": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "keywords": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "categories": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "license-file": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repository": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "publish": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VecStringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "edition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "badges": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "exclude": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "include": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "rust-version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TomlProfiles": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/TomlProfile"
+      }
+    },
+    "TomlProfile": {
+      "type": "object",
+      "properties": {
+        "opt-level": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlOptLevel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "lto": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "codegen-backend": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "codegen-units": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "debug": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlDebugInfo"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "split-debuginfo": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "debug-assertions": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "rpath": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "panic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "overflow-checks": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "incremental": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "dir-name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "inherits": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "strip": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StringOrBool"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "rustflags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "package": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/TomlProfile"
+          },
+          "default": null
+        },
+        "build-override": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "trim-paths": {
+          "description": "Unstable feature `-Ztrim-paths`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TomlTrimPaths"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hint-mostly-unused": {
+          "description": "Unstable feature `hint-mostly-unused`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        }
+      }
+    },
+    "TomlOptLevel": {
+      "type": "string"
+    },
+    "TomlDebugInfo": {
+      "type": "string",
+      "enum": [
+        "None",
+        "LineDirectivesOnly",
+        "LineTablesOnly",
+        "Limited",
+        "Full"
+      ]
+    },
+    "PackageIdSpec": {
+      "type": "string"
+    },
+    "TomlTrimPaths": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TomlTrimPathsValue"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "TomlTrimPathsValue": {
+      "type": "string",
+      "enum": [
+        "diagnostics",
+        "macro",
+        "object"
+      ]
+    },
     "NormalizedDependency": {
       "type": "object",
       "properties": {

--- a/crates/cargo-plumbing-schemas/resolve-features.out.schema.json
+++ b/crates/cargo-plumbing-schemas/resolve-features.out.schema.json
@@ -28,6 +28,26 @@
         "features_for",
         "features"
       ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string",
+          "const": "target"
+        }
+      },
+      "required": [
+        "reason",
+        "name",
+        "kind"
+      ]
     }
   ],
   "$defs": {

--- a/crates/cargo-plumbing-schemas/src/resolve_features.rs
+++ b/crates/cargo-plumbing-schemas/src/resolve_features.rs
@@ -63,6 +63,10 @@ pub enum ResolveFeaturesOut {
         #[serde(skip_serializing_if = "Vec::is_empty")]
         features: Vec<String>,
     },
+    Target {
+        name: String,
+        kind: String,
+    },
 }
 
 #[cfg(feature = "unstable-schema")]

--- a/crates/cargo-plumbing-schemas/src/resolve_features.rs
+++ b/crates/cargo-plumbing-schemas/src/resolve_features.rs
@@ -1,7 +1,9 @@
 use std::io::Read;
 use std::marker::PhantomData;
 
+use camino::Utf8PathBuf;
 use cargo_util_schemas::core::PackageIdSpec;
+use cargo_util_schemas::manifest::TomlManifest;
 use serde::{Deserialize, Serialize};
 
 use crate::lockfile::{NormalizedDependency, NormalizedPatch};
@@ -14,8 +16,22 @@ use crate::MessageIter;
 #[allow(clippy::large_enum_variant)]
 pub enum ResolveFeaturesIn {
     Manifest {
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        workspace: bool,
+        /// The path to the manifest file that was read.
         #[cfg_attr(feature = "unstable-schema", schemars(with = "String"))]
-        id: PackageIdSpec,
+        path: Utf8PathBuf,
+        /// The package ID specification.
+        ///
+        /// This command also outputs virtual manifests and virtual manifests don't have
+        /// [`PackageIdSpec`], hence the use of [`Option`].
+        #[cfg_attr(
+            feature = "unstable-schema",
+            schemars(with = "Option<String>", description = "The package ID specification")
+        )]
+        pkg_id: Option<PackageIdSpec>,
+        /// The fully parsed and deserialized manifest content.
+        manifest: TomlManifest,
     },
     LockedPackage {
         #[serde(flatten)]

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -173,18 +173,6 @@ fn run(args: &Args) -> CargoResult<()> {
         child.wait().expect("failed to wait for lock-dependencies");
     }
 
-    // HACK: We determine if we should include dev units or not. This workaround is implemented due
-    // to cargo API limitations.
-    //
-    // See: https://github.com/crate-ci/cargo-plumbing/pull/68#discussion_r2277484208
-    let has_dev_units = args.examples
-        || args.tests
-        || args.benches
-        || !args.example.is_empty()
-        || !args.test.is_empty()
-        || !args.bench.is_empty()
-        || args.all_targets;
-
     let _features = {
         let ids = manifests
             .into_iter()
@@ -202,9 +190,21 @@ fn run(args: &Args) -> CargoResult<()> {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped());
 
-        if has_dev_units {
-            cmd.arg("--dev-units");
+        if args.examples {
+            cmd.arg("--examples");
         }
+        if args.tests {
+            cmd.arg("--tests");
+        }
+        if args.benches {
+            cmd.arg("--benches");
+        }
+        if args.all_targets {
+            cmd.arg("--all-targets");
+        }
+        cmd.args(["--example", &args.example.join(",")]);
+        cmd.args(["--test", &args.test.join(",")]);
+        cmd.args(["--bench", &args.bench.join(",")]);
 
         let mut child = cmd.spawn().expect("failed to spawn resolve-features");
 

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -5,7 +5,6 @@ use std::process::{Command, Stdio};
 use cargo::CargoResult;
 use cargo_plumbing_schemas::locate_manifest::LocateManifestOut;
 use cargo_plumbing_schemas::read_manifest::ReadManifestOut;
-use cargo_plumbing_schemas::resolve_features::ResolveFeaturesIn;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
@@ -176,11 +175,6 @@ fn run(args: &Args) -> CargoResult<()> {
     let _features = {
         let ids = manifests
             .into_iter()
-            .filter_map(|manifest| match manifest {
-                ReadManifestOut::Manifest { pkg_id, .. } => {
-                    pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-                }
-            })
             .map(|msg| serde_json::to_string(&msg))
             .collect::<Result<Vec<_>, _>>()?
             .join("\n");

--- a/src/bin/cargo-plumbing/plumbing/resolve_features.rs
+++ b/src/bin/cargo-plumbing/plumbing/resolve_features.rs
@@ -90,7 +90,11 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
         match message? {
             ResolveFeaturesIn::LockedPackage { package } => locked_packages.push(package),
             ResolveFeaturesIn::UnusedPatches { unused } => unused_patches = Some(unused),
-            ResolveFeaturesIn::Manifest { id } => specs.push(id),
+            ResolveFeaturesIn::Manifest { pkg_id, .. } => {
+                if let Some(id) = pkg_id {
+                    specs.push(id);
+                }
+            }
         }
     }
 

--- a/src/bin/cargo-plumbing/plumbing/resolve_features.rs
+++ b/src/bin/cargo-plumbing/plumbing/resolve_features.rs
@@ -29,17 +29,39 @@ pub(crate) struct Args {
     /// Do not activate the `default` feature
     #[arg(long)]
     no_default_features: bool,
-    /// Include dev units
-    //
-    // HACK: We're asking the users if they want to include dev units or not. Ideally this should
-    // be done through stdin messages. However, due to cargo API limitations, this workaround is necessary
-    //
-    // See: https://github.com/crate-ci/cargo-plumbing/pull/68#discussion_r2277484208
-    #[arg(long, default_value_t = false)]
-    dev_units: bool,
     /// Target triple
     #[arg(long)]
     target: Vec<String>,
+    /// Include this package's library
+    #[arg(long)]
+    lib: bool,
+    /// Include all binaries
+    #[arg(long)]
+    bins: bool,
+    /// Include only the specified binaries
+    #[arg(long)]
+    bin: Vec<String>,
+    /// Include all examples
+    #[arg(long)]
+    examples: bool,
+    /// Include only the specified examples
+    #[arg(long)]
+    example: Vec<String>,
+    /// Include all tests
+    #[arg(long)]
+    tests: bool,
+    /// Include only the specified tests
+    #[arg(long)]
+    test: Vec<String>,
+    /// Include all benches
+    #[arg(long)]
+    benches: bool,
+    /// Include only the specified benches
+    #[arg(long)]
+    bench: Vec<String>,
+    /// Include all targets
+    #[arg(long)]
+    all_targets: bool,
 }
 
 pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
@@ -83,11 +105,15 @@ pub(crate) fn exec(gctx: &mut GlobalContext, args: Args) -> CargoResult<()> {
         !args.no_default_features,
     )?;
 
-    // HACK: We're asking the users if they want to include dev units or not. Ideally this should
-    // be done through stdin messages. However, due to cargo API limitations, this workaround is necessary
-    //
-    // See: https://github.com/crate-ci/cargo-plumbing/pull/68#discussion_r2277484208
-    let has_dev_units = if args.dev_units {
+    // Determine if we should include dev units from the selected targets.
+    let has_dev_units = if args.examples
+        || args.tests
+        || args.benches
+        || !args.example.is_empty()
+        || !args.test.is_empty()
+        || !args.bench.is_empty()
+        || args.all_targets
+    {
         HasDevUnits::Yes
     } else {
         HasDevUnits::No

--- a/tests/testsuite/cargo_plumbing_resolve_features/help/stdout.term.svg
+++ b/tests/testsuite/cargo_plumbing_resolve_features/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="326px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="488px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -42,13 +42,31 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>      --no-default-features            Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      --dev-units                      Include dev units</tspan>
+    <tspan x="10px" y="262px"><tspan>      --target &lt;TARGET&gt;                Target triple</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      --target &lt;TARGET&gt;                Target triple</tspan>
+    <tspan x="10px" y="280px"><tspan>      --lib                            Include this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  -h, --help                           Print help</tspan>
+    <tspan x="10px" y="298px"><tspan>      --bins                           Include all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="316px"><tspan>      --bin &lt;BIN&gt;                      Include only the specified binaries</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan>      --examples                       Include all examples</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan>      --example &lt;EXAMPLE&gt;              Include only the specified examples</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan>      --tests                          Include all tests</tspan>
+</tspan>
+    <tspan x="10px" y="388px"><tspan>      --test &lt;TEST&gt;                    Include only the specified tests</tspan>
+</tspan>
+    <tspan x="10px" y="406px"><tspan>      --benches                        Include all benches</tspan>
+</tspan>
+    <tspan x="10px" y="424px"><tspan>      --bench &lt;BENCH&gt;                  Include only the specified benches</tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan>      --all-targets                    Include all targets</tspan>
+</tspan>
+    <tspan x="10px" y="460px"><tspan>  -h, --help                           Print help</tspan>
+</tspan>
+    <tspan x="10px" y="478px">
 </tspan>
   </text>
 

--- a/tests/testsuite/resolve_features.rs
+++ b/tests/testsuite/resolve_features.rs
@@ -1,6 +1,5 @@
 use cargo_plumbing_schemas::read_lockfile::ReadLockfileOut;
 use cargo_plumbing_schemas::read_manifest::ReadManifestOut;
-use cargo_plumbing_schemas::resolve_features::ResolveFeaturesIn;
 use cargo_test_macro::cargo_test;
 use cargo_test_support::registry::{Dependency, Package, RegistryBuilder};
 use cargo_test_support::{basic_manifest, cross_compile, git, project, str};
@@ -49,11 +48,6 @@ fn package_with_path_deps() {
         .run();
     let out: String = ReadManifestOut::parse_stream(&*out.stdout)
         .filter_map(Result::ok)
-        .filter_map(|msg| match msg {
-            ReadManifestOut::Manifest { pkg_id, .. } => {
-                pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-            }
-        })
         .map(|msg| serde_json::to_string(&msg))
         .collect::<Result<Vec<_>, _>>()
         .unwrap()
@@ -176,11 +170,6 @@ fn package_with_varying_deps_sources() {
         .run();
     let out: String = ReadManifestOut::parse_stream(&*out.stdout)
         .filter_map(Result::ok)
-        .filter_map(|msg| match msg {
-            ReadManifestOut::Manifest { pkg_id, .. } => {
-                pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-            }
-        })
         .map(|msg| serde_json::to_string(&msg))
         .collect::<Result<Vec<_>, _>>()
         .unwrap()
@@ -292,11 +281,6 @@ fn package_with_features() {
         .run();
     let out: String = ReadManifestOut::parse_stream(&*out.stdout)
         .filter_map(Result::ok)
-        .filter_map(|msg| match msg {
-            ReadManifestOut::Manifest { pkg_id, .. } => {
-                pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-            }
-        })
         .map(|msg| serde_json::to_string(&msg))
         .collect::<Result<Vec<_>, _>>()
         .unwrap()
@@ -487,11 +471,6 @@ fn package_with_optional_dep_without_features() {
         .run();
     let out: String = ReadManifestOut::parse_stream(&*out.stdout)
         .filter_map(Result::ok)
-        .filter_map(|msg| match msg {
-            ReadManifestOut::Manifest { pkg_id, .. } => {
-                pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-            }
-        })
         .map(|msg| serde_json::to_string(&msg))
         .collect::<Result<Vec<_>, _>>()
         .unwrap()
@@ -639,11 +618,6 @@ fn package_with_proc_macro_deps_features() {
         .run();
     let out: String = ReadManifestOut::parse_stream(&*out.stdout)
         .filter_map(Result::ok)
-        .filter_map(|msg| match msg {
-            ReadManifestOut::Manifest { pkg_id, .. } => {
-                pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-            }
-        })
         .map(|msg| serde_json::to_string(&msg))
         .collect::<Result<Vec<_>, _>>()
         .unwrap()
@@ -741,11 +715,6 @@ fn package_with_target_specific_dep() {
         .run();
     let out: String = ReadManifestOut::parse_stream(&*out.stdout)
         .filter_map(Result::ok)
-        .filter_map(|msg| match msg {
-            ReadManifestOut::Manifest { pkg_id, .. } => {
-                pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-            }
-        })
         .map(|msg| serde_json::to_string(&msg))
         .collect::<Result<Vec<_>, _>>()
         .unwrap()
@@ -873,11 +842,6 @@ fn workspace_package_with_members_with_features() {
         .run();
     let out: String = ReadManifestOut::parse_stream(&*out.stdout)
         .filter_map(Result::ok)
-        .filter_map(|msg| match msg {
-            ReadManifestOut::Manifest { pkg_id, .. } => {
-                pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-            }
-        })
         .map(|msg| serde_json::to_string(&msg))
         .collect::<Result<Vec<_>, _>>()
         .unwrap()
@@ -1093,11 +1057,6 @@ fn package_with_dev_deps() {
         .run();
     let out: String = ReadManifestOut::parse_stream(&*out.stdout)
         .filter_map(Result::ok)
-        .filter_map(|msg| match msg {
-            ReadManifestOut::Manifest { pkg_id, .. } => {
-                pkg_id.map(|id| ResolveFeaturesIn::Manifest { id })
-            }
-        })
         .map(|msg| serde_json::to_string(&msg))
         .collect::<Result<Vec<_>, _>>()
         .unwrap()

--- a/tests/testsuite/resolve_features.rs
+++ b/tests/testsuite/resolve_features.rs
@@ -1142,8 +1142,9 @@ fn package_with_dev_deps() {
         )
         .run();
 
+    // `--examples` activates dev dependencies
     p.cargo_plumbing("plumbing resolve-features")
-        .arg("--dev-units")
+        .arg("--examples")
         .with_stdin(&stdin)
         .with_status(0)
         .with_stdout_data(


### PR DESCRIPTION
Implements target selection for `resolve-features` which removes the `--dev-units` flag.