### PR TITLE
refactor: Use lockfile schemas from cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,11 +25,12 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.11.5"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+checksum = "a8ee2f071d418442e50c643c4e7a4051ce3abd9dba11713cc6cdf4f4a3f3cca5"
 dependencies = [
  "anstyle",
+ "memchr",
  "unicode-width",
 ]
 
@@ -231,7 +232,7 @@ dependencies = [
 [[package]]
 name = "cargo"
 version = "0.92.0"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "annotate-snippets",
  "anstream",
@@ -307,12 +308,13 @@ dependencies = [
  "url",
  "walkdir",
  "windows-sys 0.60.2",
+ "winnow",
 ]
 
 [[package]]
 name = "cargo-credential"
 version = "0.4.9"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "anyhow",
  "libc",
@@ -325,8 +327,8 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-libsecret"
-version = "0.5.2"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+version = "0.5.3"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "anyhow",
  "cargo-credential",
@@ -335,8 +337,8 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.4.17"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+version = "0.4.18"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "cargo-credential",
  "security-framework",
@@ -344,8 +346,8 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-wincred"
-version = "0.4.17"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+version = "0.4.18"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "cargo-credential",
  "windows-sys 0.60.2",
@@ -354,7 +356,7 @@ dependencies = [
 [[package]]
 name = "cargo-platform"
 version = "0.3.1"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "serde",
 ]
@@ -396,13 +398,13 @@ dependencies = [
 
 [[package]]
 name = "cargo-test-macro"
-version = "0.4.6"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+version = "0.4.7"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.8.1"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+version = "0.8.2"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -430,8 +432,8 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.24"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+version = "0.2.25"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -452,8 +454,8 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.10.1"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+version = "0.10.2"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "schemars",
  "semver",
@@ -628,8 +630,8 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.40.14"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+version = "0.40.15"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "curl",
  "percent-encoding",
@@ -2960,7 +2962,7 @@ checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
 [[package]]
 name = "rustfix"
 version = "0.9.3"
-source = "git+https://github.com/rust-lang/cargo?branch=master#15165cac21cfcf8e3d187c3d6ab3610813cafadc"
+source = "git+https://github.com/rust-lang/cargo?branch=master#ee515e6defeb8499d76e3c7c3baad10b729cf2d5"
 dependencies = [
  "serde",
  "serde_json",
@@ -4066,9 +4068,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/crates/cargo-plumbing-schemas/src/lockfile.rs
+++ b/crates/cargo-plumbing-schemas/src/lockfile.rs
@@ -7,10 +7,8 @@
 //! future, they will be used for other lockfile-related commands, such as `lock-dependencies`
 //! and `write-lockfile`.
 
-use std::fmt;
-
 use cargo_util_schemas::core::PackageIdSpec;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -43,8 +41,7 @@ pub struct NormalizedDependency {
     #[cfg_attr(feature = "unstable-schema", schemars(with = "String"))]
     pub id: PackageIdSpec,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "unstable-schema", schemars(with = "Option<String>"))]
-    pub rev: Option<Precise>,
+    pub rev: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checksum: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -53,44 +50,4 @@ pub struct NormalizedDependency {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "unstable-schema", schemars(with = "Option<String>"))]
     pub replace: Option<PackageIdSpec>,
-}
-
-#[derive(Eq, PartialEq, Clone, Debug, Hash, Ord, PartialOrd)]
-pub enum Precise {
-    Locked,
-    GitUrlFragment(String),
-}
-
-impl fmt::Display for Precise {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Precise::Locked => "locked".fmt(f),
-            Precise::GitUrlFragment(s) => s.fmt(f),
-        }
-    }
-}
-
-impl Serialize for Precise {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = self.to_string();
-        serializer.serialize_str(&s)
-    }
-}
-
-impl<'de> Deserialize<'de> for Precise {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-
-        if s == "locked" {
-            Ok(Precise::Locked)
-        } else {
-            Ok(Precise::GitUrlFragment(s))
-        }
-    }
 }

--- a/src/bin/cargo-plumbing/plumbing/write_lockfile.rs
+++ b/src/bin/cargo-plumbing/plumbing/write_lockfile.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use cargo::core::SourceKind;
 use cargo::util::Filesystem;
 use cargo::{CargoResult, GlobalContext};
-use cargo_plumbing_schemas::lockfile::{NormalizedDependency, Precise};
+use cargo_plumbing_schemas::lockfile::NormalizedDependency;
 use cargo_plumbing_schemas::write_lockfile::WriteLockfileIn;
 use url::Url;
 
@@ -139,7 +139,7 @@ fn emit_package(package: NormalizedDependency, out: &mut String) {
     out.push('\n');
 }
 
-fn emit_source_value(url: &Url, kind: &SourceKind, rev: &Option<Precise>, out: &mut String) {
+fn emit_source_value(url: &Url, kind: &SourceKind, rev: &Option<String>, out: &mut String) {
     if let Some(protocol) = kind.protocol() {
         out.push_str(&format!("{protocol}+"));
     }

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -129,7 +129,6 @@ pub struct EncodableSourceId {
     pub kind: SourceKind,
     pub url: Url,
     pub precise: Option<String>,
-    pub encoded: bool,
 }
 
 impl EncodableSourceId {
@@ -137,16 +136,6 @@ impl EncodableSourceId {
         Self {
             url,
             kind,
-            encoded: true,
-            precise: precise.map(|s| s.to_owned()),
-        }
-    }
-
-    pub fn without_url_encoded(url: Url, precise: Option<&'static str>, kind: SourceKind) -> Self {
-        Self {
-            url,
-            kind,
-            encoded: false,
             precise: precise.map(|s| s.to_owned()),
         }
     }
@@ -166,7 +155,6 @@ impl EncodableSourceId {
                 Ok(Self {
                     url,
                     kind: SourceKind::Git(reference),
-                    encoded: false,
                     precise,
                 })
             }
@@ -175,7 +163,6 @@ impl EncodableSourceId {
                 Ok(Self {
                     url,
                     kind: SourceKind::Registry,
-                    encoded: false,
                     precise: None,
                 })
             }
@@ -184,7 +171,6 @@ impl EncodableSourceId {
                 Ok(Self {
                     url,
                     kind: SourceKind::SparseRegistry,
-                    encoded: false,
                     precise: None,
                 })
             }
@@ -193,7 +179,6 @@ impl EncodableSourceId {
                 Ok(Self {
                     url,
                     kind: SourceKind::Path,
-                    encoded: false,
                     precise: None,
                 })
             }
@@ -437,7 +422,7 @@ pub fn encodable_source_id(id: SourceId, version: ResolveVersion) -> Option<Enco
                 id.kind().clone(),
             )
         } else {
-            EncodableSourceId::without_url_encoded(
+            EncodableSourceId::new(
                 id.url().clone(),
                 id.precise_git_fragment(),
                 id.kind().clone(),

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -12,7 +12,6 @@ use cargo::core::{
 };
 use cargo::util::interning::InternedString;
 use cargo::CargoResult;
-use cargo_plumbing_schemas::lockfile::Precise;
 use serde::{de, ser, Deserialize, Serialize};
 use url::Url;
 
@@ -129,7 +128,7 @@ pub struct EncodableDependency {
 pub struct EncodableSourceId {
     pub kind: SourceKind,
     pub url: Url,
-    pub precise: Option<Precise>,
+    pub precise: Option<String>,
     pub encoded: bool,
 }
 
@@ -139,13 +138,7 @@ impl EncodableSourceId {
             url,
             kind,
             encoded: true,
-            precise: precise.map(|s| {
-                if s == "locked" {
-                    Precise::Locked
-                } else {
-                    Precise::GitUrlFragment(s.to_owned())
-                }
-            }),
+            precise: precise.map(|s| s.to_owned()),
         }
     }
 
@@ -154,13 +147,7 @@ impl EncodableSourceId {
             url,
             kind,
             encoded: false,
-            precise: precise.map(|s| {
-                if s == "locked" {
-                    Precise::Locked
-                } else {
-                    Precise::GitUrlFragment(s.to_owned())
-                }
-            }),
+            precise: precise.map(|s| s.to_owned()),
         }
     }
 
@@ -180,7 +167,7 @@ impl EncodableSourceId {
                     url,
                     kind: SourceKind::Git(reference),
                     encoded: false,
-                    precise: precise.map(Precise::GitUrlFragment),
+                    precise,
                 })
             }
             "registry" => {
@@ -189,7 +176,7 @@ impl EncodableSourceId {
                     url,
                     kind: SourceKind::Registry,
                     encoded: false,
-                    precise: Some(Precise::Locked),
+                    precise: None,
                 })
             }
             "sparse" => {
@@ -198,7 +185,7 @@ impl EncodableSourceId {
                     url,
                     kind: SourceKind::SparseRegistry,
                     encoded: false,
-                    precise: Some(Precise::Locked),
+                    precise: None,
                 })
             }
             "path" => {

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is a temporary copy from the cargo codebase.
 
+use std::cmp::{Eq, Ordering, PartialEq};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
@@ -124,58 +125,41 @@ pub struct EncodableDependency {
     pub replace: Option<EncodablePackageId>,
 }
 
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct EncodableSourceId {
+    pub source_str: String,
     pub kind: SourceKind,
     pub url: Url,
-    pub precise: Option<String>,
 }
 
 impl EncodableSourceId {
-    pub fn new(string: &str) -> CargoResult<Self> {
-        let (kind, url) = string
+    pub fn new(source: String) -> CargoResult<Self> {
+        let source_str = source.clone();
+        let (kind, url) = source
             .split_once('+')
-            .ok_or_else(|| anyhow::format_err!("invalid source `{}`", string))?;
+            .ok_or_else(|| anyhow::format_err!("invalid URL"))?;
 
-        match kind {
+        let url = Url::parse(if kind == "sparse" { &source } else { url })
+            .map_err(|e| anyhow::format_err!("invalid url `{}`: {}", url, e))?;
+
+        let kind = match kind {
             "git" => {
-                let mut url = str_to_url(url)?;
                 let reference = GitReference::from_query(url.query_pairs());
-                let precise = url.fragment().map(|s| s.to_owned());
-                url.set_fragment(None);
-                url.set_query(None);
-                Ok(Self {
-                    url,
-                    kind: SourceKind::Git(reference),
-                    precise,
-                })
+                SourceKind::Git(reference)
             }
-            "registry" => {
-                let url = str_to_url(url)?;
-                Ok(Self {
-                    url,
-                    kind: SourceKind::Registry,
-                    precise: None,
-                })
+            "registry" => SourceKind::Registry,
+            "sparse" => SourceKind::SparseRegistry,
+            "path" => SourceKind::Path,
+            kind => {
+                anyhow::bail!("unsupported source protocol: {}", kind);
             }
-            "sparse" => {
-                let url = str_to_url(string)?;
-                Ok(Self {
-                    url,
-                    kind: SourceKind::SparseRegistry,
-                    precise: None,
-                })
-            }
-            "path" => {
-                let url = str_to_url(url)?;
-                Ok(Self {
-                    url,
-                    kind: SourceKind::Path,
-                    precise: None,
-                })
-            }
-            kind => Err(anyhow::format_err!("unsupported source protocol: {}", kind)),
-        }
+        };
+
+        Ok(Self {
+            source_str,
+            kind,
+            url,
+        })
     }
 
     fn is_path(&self) -> bool {
@@ -185,24 +169,7 @@ impl EncodableSourceId {
 
 impl fmt::Display for EncodableSourceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(protocol) = self.kind.protocol() {
-            write!(f, "{protocol}+")?;
-        }
-        write!(f, "{}", self.url)?;
-        if let Self {
-            kind: SourceKind::Git(ref reference),
-            ref precise,
-            ..
-        } = self
-        {
-            if let Some(pretty) = reference.pretty_ref(true) {
-                write!(f, "?{pretty}")?;
-            }
-            if let Some(precise) = precise.as_ref() {
-                write!(f, "#{precise}")?;
-            }
-        }
-        Ok(())
+        write!(f, "{}", self.source_str)
     }
 }
 
@@ -225,7 +192,29 @@ impl<'de> Deserialize<'de> for EncodableSourceId {
         D: de::Deserializer<'de>,
     {
         let string = String::deserialize(d)?;
-        Self::new(&string).map_err(de::Error::custom)
+        Self::new(string).map_err(de::Error::custom)
+    }
+}
+
+impl PartialEq for EncodableSourceId {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind && self.url == other.url
+    }
+}
+
+impl Eq for EncodableSourceId {}
+
+impl PartialOrd for EncodableSourceId {
+    fn partial_cmp(&self, other: &EncodableSourceId) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for EncodableSourceId {
+    fn cmp(&self, other: &EncodableSourceId) -> Ordering {
+        self.kind
+            .cmp(&other.kind)
+            .then_with(|| self.url.cmp(&other.url))
     }
 }
 
@@ -259,7 +248,7 @@ impl FromStr for EncodablePackageId {
         let source_id = match s.next() {
             Some(s) => {
                 if let Some(s) = s.strip_prefix('(').and_then(|s| s.strip_suffix(')')) {
-                    Some(EncodableSourceId::new(s)?)
+                    Some(EncodableSourceId::new(s.to_owned())?)
                 } else {
                     anyhow::bail!("invalid serialized PackageId")
                 }
@@ -296,21 +285,6 @@ impl<'de> Deserialize<'de> for EncodablePackageId {
                 .map_err(de::Error::custom)
         })
     }
-}
-
-fn str_to_url(string: &str) -> CargoResult<Url> {
-    Url::parse(string).map_err(|s| {
-        if string.starts_with("git@") {
-            anyhow::format_err!(
-                "invalid url `{}`: {}; try using `{}` instead",
-                string,
-                s,
-                format_args!("ssh://{}", string.replacen(':', "/", 1))
-            )
-        } else {
-            anyhow::format_err!("invalid url `{}`: {}", string, s)
-        }
-    })
 }
 
 pub struct EncodeState<'a> {
@@ -409,9 +383,9 @@ pub fn encodable_source_id(id: SourceId, version: ResolveVersion) -> Option<Enco
     } else {
         Some(
             if version >= ResolveVersion::V4 {
-                EncodableSourceId::new(&id.as_url().to_string())
+                EncodableSourceId::new(id.as_url().to_string())
             } else {
-                EncodableSourceId::new(&id.as_url().to_string())
+                EncodableSourceId::new(id.as_url().to_string())
             }
             .unwrap(),
         )

--- a/src/ops/resolve.rs
+++ b/src/ops/resolve.rs
@@ -6,9 +6,7 @@ use cargo::core::{
 };
 use cargo::util::Graph;
 use cargo::CargoResult;
-use cargo_plumbing_schemas::lockfile::{
-    NormalizedDependency, NormalizedPatch, NormalizedResolve, Precise,
-};
+use cargo_plumbing_schemas::lockfile::{NormalizedDependency, NormalizedPatch, NormalizedResolve};
 
 use crate::cargo::core::resolver::encode::{
     build_path_deps, EncodableDependency, EncodablePackageId, EncodableResolve, Metadata, Patch,
@@ -191,7 +189,7 @@ pub fn get_path_deps_source_id<'a>(
 pub fn spec_to_id(
     spec: PackageIdSpec,
     source_id: Option<&SourceId>,
-    git_rev: Option<Precise>,
+    git_rev: Option<String>,
 ) -> CargoResult<Option<PackageId>> {
     if let Some(kind) = spec.kind() {
         if let Some(url) = spec.url() {
@@ -202,10 +200,8 @@ pub fn spec_to_id(
                     // means the GitReference from source itself may or may not have what we need.
                     // Therefore, we need a `git_rev` to construct the source ID.
                     SourceKind::Git(git_reference) => {
-                        let mut source_id = SourceId::for_git(url, git_reference.clone())?;
-                        if let Some(Precise::GitUrlFragment(fragment)) = git_rev {
-                            source_id = source_id.with_git_precise(Some(fragment));
-                        }
+                        let source_id = SourceId::for_git(url, git_reference.clone())?
+                            .with_git_precise(git_rev);
                         Ok(source_id)
                     }
                     SourceKind::Registry | SourceKind::SparseRegistry => {

--- a/src/ops/resolve.rs
+++ b/src/ops/resolve.rs
@@ -347,7 +347,10 @@ pub fn normalize_dependency(dep: EncodableDependency) -> CargoResult<NormalizedD
     let mut source = None;
 
     if let Some(s) = dep.source {
-        id = id.with_url(s.url.clone()).with_kind(s.kind.clone());
+        let mut url = s.url.clone();
+        url.set_fragment(None);
+        url.set_query(None);
+        id = id.with_url(url).with_kind(s.kind.clone());
         source = Some(s);
     }
 
@@ -366,7 +369,7 @@ pub fn normalize_dependency(dep: EncodableDependency) -> CargoResult<NormalizedD
     };
 
     let rev = match source {
-        Some(s) if matches!(s.kind, SourceKind::Git(..)) => s.precise,
+        Some(s) if matches!(s.kind, SourceKind::Git(..)) => s.url.fragment().map(|f| f.to_owned()),
         _ => None,
     };
 
@@ -388,7 +391,10 @@ pub fn normalize_package_id(package_id: EncodablePackageId) -> CargoResult<Packa
     }
 
     if let Some(source) = package_id.source {
-        id = id.with_url(source.url).with_kind(source.kind);
+        let mut url = source.url.clone();
+        url.set_fragment(None);
+        url.set_query(None);
+        id = id.with_url(url).with_kind(source.kind);
     }
 
     Ok(id)


### PR DESCRIPTION
Replaces the local fork of lockfile schemas with the lockfile schemas from `cargo-util-schemas` from https://github.com/rust-lang/cargo/pull/15980.

Opening as draft as this is still a work in progress. See comments for info.